### PR TITLE
update elk_api.d.ts to fix wrong promise types in ELK interface

### DIFF
--- a/typings/elk-api.d.ts
+++ b/typings/elk-api.d.ts
@@ -100,9 +100,9 @@ export interface ElkLayoutCategoryDescription extends ElkCommonDescription {
 
 export interface ELK {
     layout(graph: ElkNode, args?: ElkLayoutArguments): Promise<ElkNode>;
-    knownLayoutAlgorithms(): Promise<ElkLayoutAlgorithmDescription>
-    knownLayoutOptions(): Promise<ElkLayoutOptionDescription>
-    knownLayoutCategories(): Promise<ElkLayoutCategoryDescription>
+    knownLayoutAlgorithms(): Promise<ElkLayoutAlgorithmDescription[]>
+    knownLayoutOptions(): Promise<ElkLayoutOptionDescription[]>
+    knownLayoutCategories(): Promise<ElkLayoutCategoryDescription[]>
 }
 
 export interface ELKConstructorArguments {


### PR DESCRIPTION
This error raise transpile error and need to be fixed to allow using ELKJS in typed script.