### PR TITLE
Update ElkNode type

### DIFF
--- a/typings/elk-api.d.ts
+++ b/typings/elk-api.d.ts
@@ -31,7 +31,7 @@ export interface ElkShape extends ElkGraphElement {
 export interface ElkNode extends ElkShape {
     children?: ElkNode[]
     ports?: ElkPort[]
-    edges?: ElkEdge[]
+    edges?: ElkExtendedEdge[]
 }
 
 export interface ElkPort extends ElkShape { }

--- a/typings/elk-api.d.ts
+++ b/typings/elk-api.d.ts
@@ -28,6 +28,12 @@ export interface ElkShape extends ElkGraphElement {
     height?: number
 }
 
+export interface ElkNode extends ElkShape {
+    children?: ElkNode[]
+    ports?: ElkPort[]
+    edges?: ElkEdge[]
+}
+
 export interface ElkInputNode extends ElkShape {
     children?: ElkInputNode[]
     ports?: ElkPort[]
@@ -105,7 +111,7 @@ export interface ElkLayoutCategoryDescription extends ElkCommonDescription {
 }
 
 export interface ELK {
-    layout(graph: ElkInputNode, args?: ElkLayoutArguments): Promise<ElkOutputNode>;
+    layout<T extends ElkNode | ElkInputNode>(graph: T, args?: ElkLayoutArguments): Promise<T extends ElkInputNode ? ElkOutputNode : ElkNode>;
     knownLayoutAlgorithms(): Promise<ElkLayoutAlgorithmDescription[]>
     knownLayoutOptions(): Promise<ElkLayoutOptionDescription[]>
     knownLayoutCategories(): Promise<ElkLayoutCategoryDescription[]>

--- a/typings/elk-api.d.ts
+++ b/typings/elk-api.d.ts
@@ -28,8 +28,14 @@ export interface ElkShape extends ElkGraphElement {
     height?: number
 }
 
-export interface ElkNode extends ElkShape {
-    children?: ElkNode[]
+export interface ElkInputNode extends ElkShape {
+    children?: ElkInputNode[]
+    ports?: ElkPort[]
+    edges: (ElkPrimitiveEdge | ElkExtendedEdge)[]
+}
+
+export interface ElkOutputNode extends ElkShape {
+    children?: ElkOutputNode[]
     ports?: ElkPort[]
     edges?: ElkExtendedEdge[]
 }
@@ -99,7 +105,7 @@ export interface ElkLayoutCategoryDescription extends ElkCommonDescription {
 }
 
 export interface ELK {
-    layout(graph: ElkNode, args?: ElkLayoutArguments): Promise<ElkNode>;
+    layout(graph: ElkInputNode, args?: ElkLayoutArguments): Promise<ElkOutputNode>;
     knownLayoutAlgorithms(): Promise<ElkLayoutAlgorithmDescription[]>
     knownLayoutOptions(): Promise<ElkLayoutOptionDescription[]>
     knownLayoutCategories(): Promise<ElkLayoutCategoryDescription[]>


### PR DESCRIPTION
Thanks for this library it's a great way to render dags. While using this in one of my projects I noticed an issue with the typings, `ElkNode` types the edges field to `ElkEdge[]` but the actual value aligns with the `ElkExtendedEdge` type.