### PR TITLE
Fix typescript types

### DIFF
--- a/typings/elk-api.d.ts
+++ b/typings/elk-api.d.ts
@@ -16,7 +16,7 @@ export interface ElkPoint {
 }
 
 export interface ElkGraphElement {
-    id: string
+    id?: string
     labels?: ElkLabel[]
     layoutOptions?: LayoutOptions
 }
@@ -29,33 +29,31 @@ export interface ElkShape extends ElkGraphElement {
 }
 
 export interface ElkNode extends ElkShape {
+    id: string
     children?: ElkNode[]
-    ports?: ElkPort[]
-    edges?: ElkEdge[]
-}
-
-export interface ElkInputNode extends ElkShape {
-    children?: ElkInputNode[]
-    ports?: ElkPort[]
-    edges: (ElkPrimitiveEdge | ElkExtendedEdge)[]
-}
-
-export interface ElkOutputNode extends ElkShape {
-    children?: ElkOutputNode[]
     ports?: ElkPort[]
     edges?: ElkExtendedEdge[]
 }
 
-export interface ElkPort extends ElkShape { }
-
-export interface ElkLabel extends ElkShape {
-    text: string
+export interface ElkPort extends ElkShape {
+    id: string
 }
 
+export interface ElkLabel extends ElkShape {
+    text?: string
+}
+
+/**
+ * @deprecated use ElkExtendedEdge directly
+ */
 export interface ElkEdge extends ElkGraphElement {
+    id: string
     junctionPoints?: ElkPoint[]
 }
 
+/**
+ * @deprecated use ElkExtendedEdge instead
+ */
 export interface ElkPrimitiveEdge extends ElkEdge {
     source: string
     sourcePort?: string
@@ -69,10 +67,11 @@ export interface ElkPrimitiveEdge extends ElkEdge {
 export interface ElkExtendedEdge extends ElkEdge {
     sources: string[]
     targets: string[]
-    sections: ElkEdgeSection[]
+    sections?: ElkEdgeSection[]
 }
 
 export interface ElkEdgeSection extends ElkGraphElement {
+    id: string
     startPoint: ElkPoint
     endPoint: ElkPoint
     bendPoints?: ElkPoint[]
@@ -111,7 +110,7 @@ export interface ElkLayoutCategoryDescription extends ElkCommonDescription {
 }
 
 export interface ELK {
-    layout<T extends ElkNode | ElkInputNode>(graph: T, args?: ElkLayoutArguments): Promise<T extends ElkInputNode ? ElkOutputNode : ElkNode>;
+    layout(graph: ElkNode, args?: ElkLayoutArguments): Promise<ElkNode>;
     knownLayoutAlgorithms(): Promise<ElkLayoutAlgorithmDescription[]>
     knownLayoutOptions(): Promise<ElkLayoutOptionDescription[]>
     knownLayoutCategories(): Promise<ElkLayoutCategoryDescription[]>

--- a/typings/elk-worker.d.ts
+++ b/typings/elk-worker.d.ts
@@ -1,0 +1,1 @@
+export type Worker = Worker


### PR DESCRIPTION
This PR fixes two mistakes in the type definition:
* Labels don't need id's: [https://www.eclipse.org/elk/documentation/tooldevelopers/graphdatastructure/jsonformat.html#nodes-ports-labels-edges-and-edge-sections](All elements, **except labels**, must have an id that uniquely identifies them.)
* Extended Edges don't need sections: [https://www.eclipse.org/elk/documentation/tooldevelopers/graphdatastructure/jsonformat.html#extended-edges](sections does not have a star, indicating it's optional.)

It also changes the edges type of ElkNode to be the same as ElkInputNode, from `ElkEdge[]` to `(ElkPrimitiveEdge | ElkExtendedEdge)[]`. As this helps with casting JSON to the right types, otherwise you get this error: 

```
TS2322: Type '{ id: string; sources: string[]; targets: string[]; }' is not assignable to type 'ElkEdge'. 
Object literal may only specify known properties, and '"sources"' does not exist in type 'ElkEdge'.
```