### PR TITLE
Add capellambse-context-diagrams to example users

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,6 +361,7 @@ In the following a list of asorted links to other projects and sites that may pr
 - Wrapping elkjs into a [docker-based microservice](https://github.com/elbosso/elkjsmicroservice)
 - [sprotty](https://github.com/eclipse/sprotty) - A diagramming framework
 - [Eclipse 4diac](https://www.fordiac.org)
+- [capellambse-context-diagrams](https://github.com/DSD-DBS/capellambse-context-diagrams) - Generating systems engineering context diagrams for [Capella](https://www.eclipse.org/capella/) in Python
 
 Note: We are happy to extend this list further, so please contact us if you have a project to add
 


### PR DESCRIPTION
Hi dear kieler/ELK team,

thank you again for the cool tools that you build and maintain.

Over a year ago I found ELK and tried to use it in eclipse for our MBSE modeling tool Capella. Unfortunately the eclipse plugin is not ready to deal with the metamodel of Capella which causes all sorts of weird routing and placing behaviors (esp. on hierarchical diagrams). That's why we looked into the underlying tools and thank god it was open source and linked to the [elk-live](https://github.com/kieler/elk-live) repo such that testing the various config options during development was a breeze.  This enabled us to build a tool for diagram generation which don't need to be stored in the native Capella model and are layouted automatically.

Today we are enjoying our synthesized systems engineering context diagrams, layouted by the latest version of elkjs (currently 0.8.1) in many rendered deliverables. Now we decided to publish this library and I think it's a good idea to include it into the _Example Users_ section of elkjs' README.

Feel free to change the descriptive text for your needs.