### PR TITLE
Add `container` property to `ElkEdge`

### DIFF
--- a/typings/elk-api.d.ts
+++ b/typings/elk-api.d.ts
@@ -50,6 +50,7 @@ export interface ElkLabel extends ElkShape {
  */
 export interface ElkEdge extends ElkGraphElement {
     id: string
+    container: string
     junctionPoints?: ElkPoint[]
 }
 

--- a/typings/elk-api.d.ts
+++ b/typings/elk-api.d.ts
@@ -50,7 +50,7 @@ export interface ElkLabel extends ElkShape {
  */
 export interface ElkEdge extends ElkGraphElement {
     id: string
-    container: string
+    container?: string
     junctionPoints?: ElkPoint[]
 }
 


### PR DESCRIPTION
[ELK#775](https://github.com/eclipse/elk/pull/775) added a `container` property to edges:

> Write a container property into each edge after layout. This gives the id of the node that was this edge's container, and helps the user interpret the route points in the right coord system.

Updating the `ElkEdge` type to reflect this and avoid type errors.

Note to reviewers: not sure if this type belongs in `ElkEdge`, or `ElkExtendedEdge`. Based on the upstream PR, I think this should be a non-optional property but happy to make changes!