### PR TITLE
Update ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version: [ 14.x, 16.x, 18.x ]
-        java-version: [ 8, 11, 13, 15, 17 ] 
+        java-version: [ 11, 13, 15, 17 ] 
 
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
Removes Java 8, since ELK 0.9.0 no longer supports Java 8.