### PR TITLE
 #208 Add worker termination conditions and method

### DIFF
--- a/src/js/elk-api.js
+++ b/src/js/elk-api.js
@@ -1,10 +1,10 @@
 /*******************************************************************************
  * Copyright (c) 2017 Kiel University and others.
- * 
- * This program and the accompanying materials are made 
- * available under the terms of the Eclipse Public License 2.0 
- * which is available at https://www.eclipse.org/legal/epl-2.0/ 
- * 
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
  * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 export default class ELK {
@@ -89,6 +89,7 @@ export default class ELK {
   }
 
   terminateWorker() {
+    if(this.worker)
     this.worker.terminate()
   }
 
@@ -144,11 +145,11 @@ class PromisedWorker {
   }
 
   terminate() {
-    if (this.worker.terminate) {
+    if (this.worker) {
       this.worker.terminate()
     }
   }
-  
+
   convertGwtStyleError(err) {
     if (!err) {
       return
@@ -167,5 +168,5 @@ class PromisedWorker {
       }
       delete err['__java$exception']
     }
-  }  
+  }
 }

--- a/typings/elk-api.d.ts
+++ b/typings/elk-api.d.ts
@@ -1,10 +1,10 @@
 /*******************************************************************************
  * Copyright (c) 2019 TypeFox and others.
- * 
- * This program and the accompanying materials are made 
- * available under the terms of the Eclipse Public License 2.0 
- * which is available at https://www.eclipse.org/legal/epl-2.0/ 
- * 
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
  * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 
@@ -116,6 +116,7 @@ export interface ELK {
     knownLayoutAlgorithms(): Promise<ElkLayoutAlgorithmDescription[]>
     knownLayoutOptions(): Promise<ElkLayoutOptionDescription[]>
     knownLayoutCategories(): Promise<ElkLayoutCategoryDescription[]>
+    terminateWorker(): void;
 }
 
 export interface ELKConstructorArguments {


### PR DESCRIPTION
closes #208 

- Adds `terminateWorker` to `ELK` interface
- Checks for worker before calling or accessing `terminate`