### PR TITLE
Enhance `layout` method typing with generic type

### DIFF
--- a/typings/elk-api.d.ts
+++ b/typings/elk-api.d.ts
@@ -112,7 +112,10 @@ export interface ElkLayoutCategoryDescription extends ElkCommonDescription {
 }
 
 export interface ELK {
-    layout(graph: ElkNode, args?: ElkLayoutArguments): Promise<ElkNode>;
+    layout<T extends ElkNode>(
+        graph: T,
+        args?: ElkLayoutArguments
+    ): Promise<Omit<T, 'children'> & { children?: (T['children'][number] & ElkNode)[] }>;
     knownLayoutAlgorithms(): Promise<ElkLayoutAlgorithmDescription[]>
     knownLayoutOptions(): Promise<ElkLayoutOptionDescription[]>
     knownLayoutCategories(): Promise<ElkLayoutCategoryDescription[]>


### PR DESCRIPTION
The `layout` method doesn't strictly accept only pure `ElkNode` type as `graph` argument but it can be extended with custom properties. As the function is also applied to `children` the return type needs to merge also child type. 
This is very useful to not lose typings when using `ELK.layout()` with some custom data (that are compatible with the library).

Problematic example:
```ts
  const graphWithCustomData = {
    id: 'root',
    children: [{ id: '1', myCustomData: 'test' }]
  };

  elk
    .layout(graphWithCustomData)
    .then((layoutedGraph) => {
      layoutedGraph.children?.[0].myCustomData; // Property 'myCustomData' does not exist on type 'ElkNode'.ts(2339)
    })
```