### PR TITLE
Hoist FakeWorker out of conditional

### DIFF
--- a/src/java/org/eclipse/elk/js/ElkJs.java
+++ b/src/java/org/eclipse/elk/js/ElkJs.java
@@ -88,32 +88,27 @@ public class ElkJs implements EntryPoint {
             }
         }
 
-        // the below works for real web workers but not for 'simulated' web worker, such as for nodejs
-        // if (typeof WorkerGlobalScope !== 'undefined' && self instanceof WorkerGlobalScope) {
-        if (typeof document === "undefined" && typeof self !== "undefined") {
-            // real web worker
-            var dispatcher = new Dispatcher(self)
-            self.onmessage = dispatcher.saveDispatch
-        } else if (typeof module !== "undefined" && module.exports) {
-            // export a fake worker (note that the post/receive functions are inverted)
+        // FakeWorker: always defined, always exported in CJS contexts so
+        // consumers can always supply it as a workerFactory. The env-
+        // detection check below decides whether to additionally wire
+        // self.onmessage for real Worker contexts.
+        function FakeWorker(url) {
+            var _this = this;
 
-            // let it look like a regular message (add the 'data' key)
-            function FakeWorker(url) {
-                var _this = this;
+            // post messages
+            this.dispatcher = new Dispatcher({
+                postMessage: function(msg) { _this.onmessage({ data: msg }) }
+            })
 
-                // post messages
-                this.dispatcher = new Dispatcher({
-                    postMessage: function(msg) { _this.onmessage({ data: msg }) }
-                })
-
-                // receive messages
-                this.postMessage = function(msg) {
-                    setTimeout(function() {
-                        _this.dispatcher.saveDispatch({ data: msg })
-                    }, 0);
-                }
+            // receive messages
+            this.postMessage = function(msg) {
+                setTimeout(function() {
+                    _this.dispatcher.saveDispatch({ data: msg })
+                }, 0);
             }
+        }
 
+        if (typeof module !== "undefined" && module.exports) {
             Object.defineProperty(exports, "__esModule", {
               value: true
             })
@@ -121,8 +116,13 @@ public class ElkJs implements EntryPoint {
                 'default': FakeWorker,
                 Worker: FakeWorker
             }
-        } else {
-            // shouldn't get here, panic!
+        }
+
+        // the below works for real web workers but not for 'simulated' web worker, such as for nodejs
+        // if (typeof WorkerGlobalScope !== 'undefined' && self instanceof WorkerGlobalScope) {
+        if (typeof document === "undefined" && typeof self !== "undefined") {
+            var dispatcher = new Dispatcher(self)
+            self.onmessage = dispatcher.saveDispatch
         }
 
     }-*/;


### PR DESCRIPTION
Fixes #377.

The JSNI block in `src/java/org/eclipse/elk/js/ElkJs.java` declared `function FakeWorker(url)` and assigned `module.exports` **inside** the `else if (typeof module...)` branch. In Node >= 22 and Bun, `self` is a global alias for `globalThis`, so the preceding `if (typeof document === undefined && typeof self !== undefined)` branch matches on main threads and the CJS export is skipped.

This change hoists the `FakeWorker` declaration to the top of the IIFE and makes the `module.exports` assignment unconditional. The env-detection `if` now only decides whether to additionally wire `self.onmessage` for real Worker contexts.

## Testing

Rebuilt `lib/elk-worker.min.js` via `./gradlew copyMinified` (existing toolchain: Gradle 7.2, GWT 2.11.0, JDK 17). Verified in the minified output that `module.exports = { default: i, Worker: i }` now sits in its own top-level `if` block, followed by a separate `if (typeof document === undefined && typeof self !== undefined)` block that wires `self.onmessage`.

Overlaid the regenerated file into a downstream consumer (Node 22 / Bun) that previously required a `delete self; require; restore self` workaround. With this patch, a plain `import { Worker } from 'elkjs/lib/elk-worker.min.js'` plus `new ELK({ workerFactory: () => new FakeWorker() })` works without any ceremony.