### PR TITLE
Restore DisCo by upgrading toolchain to fix #291 race

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,8 +18,8 @@
 plugins {
   // The documentation of the plugin [1] states "tested up to [gradle] 7.2". 
   // [1] https://xtext.github.io/xtext-gradle-plugin/xtext-builder.html
-  id 'org.xtext.builder' version '3.0.2' // according to the docu, tested up to gradle 7.2
-  id 'org.xtext.xtend'   version '3.0.2'
+  id 'org.xtext.builder' version '4.0.0'
+  id 'org.xtext.xtend'   version '4.0.0'
   id 'java'
 }
 
@@ -72,8 +72,7 @@ def elkSources = [
   "${elkRepo}/plugins/org.eclipse.elk.graph.json/src",
   "${elkRepo}/plugins/org.eclipse.elk.alg.common/src",
   // The algorithms
-  // FIXME: DisCo breaks Github Actions for unknown reasons, see https://github.com/kieler/elkjs/issues/291
-  //"${elkRepo}/plugins/org.eclipse.elk.alg.disco/src",
+  "${elkRepo}/plugins/org.eclipse.elk.alg.disco/src",
   "${elkRepo}/plugins/org.eclipse.elk.alg.force/src",
   "${elkRepo}/plugins/org.eclipse.elk.alg.layered/src",
   "${elkRepo}/plugins/org.eclipse.elk.alg.mrtree/src",
@@ -112,7 +111,7 @@ sourceSets {
     java {
       srcDirs = [ "$srcDir/elk" ]
     }
-    xtendOutputDir = "$srcDir/xtend-gen"
+    xtend.outputDir = "$srcDir/xtend-gen"
   }
 
   main {
@@ -188,7 +187,7 @@ dependencies {
 xtext {
   languages {
     melk {
-      fileExtension = 'melk'
+      fileExtensions = ['melk']
       setup = 'org.eclipse.elk.core.meta.MetaDataStandaloneSetup'
       generator.outlet.producesJava = true
     }

--- a/build.gradle
+++ b/build.gradle
@@ -28,11 +28,12 @@ tasks.withType(JavaCompile) {
   options.encoding = 'UTF-8'
 }
 
-// GWT 2.10 allows to run Java [8, 17]
-//  (http://www.gwtproject.org/release-notes.html#Release_Notes_2_10_0)
-if (!JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_1_8) 
-    || JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_18)) {
-    throw new GradleException("elkjs build requires to be run with Java [8, 17] (due to GWT compilation). You are running " + JavaVersion.current() + ".")
+// GWT 2.13 (released Feb 2025) runs on Java 11 through 21 and supports
+// Java 12-17 language features at the source/target level.
+// https://github.com/gwtproject/gwt/blob/main/RELEASE_NOTES.md
+if (!JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_1_8)
+    || JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_22)) {
+    throw new GradleException("elkjs build requires to be run with Java [8, 21] (due to GWT compilation). You are running " + JavaVersion.current() + ".")
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -41,7 +42,7 @@ if (!JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_1_8)
 
 ext.versions = [
   emfGwt: '2.12.4',
-  gwt:    '2.11.0',
+  gwt:    '2.13.0',
   guava:  '31.1-jre',
   melk:   '0.12.0-SNAPSHOT',
   xtext:  '2.36.0',

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/java/org/eclipse/elk/js/ElkJs.java
+++ b/src/java/org/eclipse/elk/js/ElkJs.java
@@ -24,8 +24,7 @@ import org.eclipse.elk.graph.*;
 import org.eclipse.elk.graph.json.*;
 
 import org.eclipse.elk.alg.common.compaction.options.*;
-// FIXME: DisCo breaks Github Actions for unknown reasons, see https://github.com/kieler/elkjs/issues/291
-//import org.eclipse.elk.alg.disco.options.*;
+import org.eclipse.elk.alg.disco.options.*;
 import org.eclipse.elk.alg.layered.options.*;
 import org.eclipse.elk.alg.force.options.*;
 import org.eclipse.elk.alg.mrtree.options.*;
@@ -145,9 +144,8 @@ public class ElkJs implements EntryPoint {
                 SERVICE.registerLayoutMetaDataProviders(new MrTreeMetaDataProvider());
             } else if (alg.equals("radial")) {
                 SERVICE.registerLayoutMetaDataProviders(new RadialMetaDataProvider());
-                // FIXME: DisCo breaks Github Actions for unknown reasons, see https://github.com/kieler/elkjs/issues/291
-   //         } else if (alg.equals("disco")) {
-   //             SERVICE.registerLayoutMetaDataProviders(new PolyominoOptions(), new DisCoMetaDataProvider());
+            } else if (alg.equals("disco")) {
+                SERVICE.registerLayoutMetaDataProviders(new PolyominoOptions(), new DisCoMetaDataProvider());
             } else if (alg.equals("sporeOverlap") || alg.equals("sporeCompaction")) {
                 SERVICE.registerLayoutMetaDataProviders(new SporeMetaDataProvider());
             } else if (alg.equals("rectpacking")) {


### PR DESCRIPTION
Restores DisCo, removed in #288 due to the intermittent `The type CompactionStrategy in Disco.melk cannot be resolved` build failure tracked in #291.

## Hypothesis

The flake is a task-ordering race in xtext-gradle-plugin 3.0.2's annotation processing. `Disco.melk` references `CompactionStrategy` (a hand-written Java enum at `org.eclipse.elk.alg.disco.options.CompactionStrategy`). On slow runners, the Xtext task processing the .melk fires before javac compiles the enum, so the type can't be resolved.

xtext-gradle-plugin 4.0.0 was rewritten with the modern Gradle Provider API, which expresses task dependencies declaratively instead of through implicit ordering. This should make the race deterministic.

## Changes

**Commit 1 — modernize toolchain (required for xtext 4.0.0):**
- Gradle wrapper 7.2 → 8.10 (xtext-gradle-plugin 4.0.0 needs Gradle 8+)
- GWT 2.11.0 → 2.13.0 (Gradle 8 + JDK 21 compat)
- Java toolchain range [8, 17] → [8, 21]

**Commit 2 — restore DisCo:**
- xtext-gradle-plugin 3.0.2 → 4.0.0 (fixes #291)
- Required DSL renames: `fileExtension` → `fileExtensions` (SetProperty), `xtendOutputDir` → `xtend.outputDir`
- Re-add `org.eclipse.elk.alg.disco/src` to elkSources
- Re-import `org.eclipse.elk.alg.disco.options.*` and the disco registration branch in `ElkJs.java`

## Verification

Built locally on JDK 21 + Gradle 8.10 + GWT 2.13. `lib/elk-worker.min.js` contains the disco algorithm registration.

Cannot reproduce the upstream CI flake locally (matching the original report). Suggest re-running the PR's CI several times to confirm the xtext bump fixes it.

## Notes

- Does **not** include the FakeWorker fix from #378 (that's its own concern; this PR is purely about disco)
- `CompactionStrategy.java` in `org.eclipse.elk.alg.disco/src/...` is a hand-written enum, not generated, so the original race is about Xtext ordering, not generation order.

Closes #291.