### PR TITLE
Adding proper LayoutOptions with docs from official elk options docs

### DIFF
--- a/typings/elk-api.d.ts
+++ b/typings/elk-api.d.ts
@@ -8,8 +8,848 @@
  * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 
+/**
+ * ELK Layout Options with descriptions based on https://www.eclipse.org/elk/reference/options.html
+ */
 export interface LayoutOptions {
-    [key: string]: string
+    /** Angle Penalty */
+    "elk.alg.libavoid.anglePenalty"?: string;
+
+    /** Spacing between pairs of ports of the same node */
+    "elk.spacing.portConnection"?: string;
+
+    /** Cluster Crossing Penalty */
+    "elk.alg.libavoid.clusterCrossingPenalty"?: string;
+
+    /** Crossing Penalty */
+    "elk.alg.libavoid.crossingPenalty"?: string;
+
+    /** Enable Hyperedges From Common Source */
+    "elk.alg.libavoid.enableHyperedgesFromCommonSource"?: string;
+
+    /** Fixed Shared Path Penalty */
+    "elk.alg.libavoid.fixedSharedPathPenalty"?: string;
+
+    /** Ideal Nudging Distance */
+    "elk.alg.libavoid.idealNudgingDistance"?: string;
+
+    /** Improve Hyperedge Routes Add/Delete */
+    "elk.alg.libavoid.improveHyperedgeRoutesMovingAddingAndDeletingJunctions"?: string;
+
+    /** Improve Hyperedge Routes */
+    "elk.alg.libavoid.improveHyperedgeRoutesMovingJunctions"?: string;
+
+    /** Marks a node as a cluster */
+    "elk.alg.libavoid.isCluster"?: string;
+
+    /** Nudge Orthogonal Segments */
+    "elk.alg.libavoid.nudgeOrthogonalSegmentsConnectedToShapes"?: string;
+
+    /** Nudge Orthogonal Touching Colinear Segments */
+    "elk.alg.libavoid.nudgeOrthogonalTouchingColinearSegments"?: string;
+
+    /** Nudge Shared Paths With Common Endpoint */
+    "elk.alg.libavoid.nudgeSharedPathsWithCommonEndPoint"?: string;
+
+    /** Penalise Orthogonal Shared Paths */
+    "elk.alg.libavoid.penaliseOrthogonalSharedPathsAtConnEnds"?: string;
+
+    /** Perform Unifying Nudging Preprocessing */
+    "elk.alg.libavoid.performUnifyingNudgingPreprocessingStep"?: string;
+
+    /** Port Direction Penalty */
+    "elk.alg.libavoid.portDirectionPenalty"?: string;
+
+    /** Default process timeout. */
+    "elk.alg.libavoid.processTimeout"?: string;
+
+    /** Reverse Direction Penalty */
+    "elk.alg.libavoid.reverseDirectionPenalty"?: string;
+
+    /** Segment Penalty */
+    "elk.alg.libavoid.segmentPenalty"?: string;
+
+    /** Shape Buffer Distance */
+    "elk.alg.libavoid.shapeBufferDistance"?: string;
+
+    /** Layout Algorithm */
+    "elk.algorithm"?: string;
+
+    /** Alignment */
+    "elk.alignment"?: string;
+
+    /** Animate */
+    "elk.animate"?: string;
+
+    /** Animation Time Factor */
+    "elk.animTimeFactor"?: string;
+
+    /** Aspect Ratio */
+    "elk.aspectRatio"?: string;
+
+    /** Bend Points */
+    "elk.bendPoints"?: string;
+
+    /** Box Layout Mode */
+    "elk.box.packingMode"?: string;
+
+    /** Child Area Height */
+    "elk.childAreaHeight"?: string;
+
+    /** Child Area Width */
+    "elk.childAreaWidth"?: string;
+
+    /** Comment Box */
+    "elk.commentBox"?: string;
+
+    /** Compaction Strategy */
+    "elk.compaction.compactionStrategy"?: string;
+
+    /** Orthogonal Compaction */
+    "elk.compaction.orthogonal"?: string;
+
+    /** Content Alignment */
+    "elk.contentAlignment"?: string;
+
+    /** Debug Mode */
+    "elk.debugMode"?: string;
+
+    /** Direction */
+    "elk.direction"?: string;
+
+    /** Connected Components Layout Algorithm */
+    "elk.disco.componentCompaction.componentLayoutAlgorithm"?: string;
+
+    /** Connected Components Compaction Strategy */
+    "elk.disco.componentCompaction.strategy"?: string;
+
+    /** DCGraph */
+    "elk.disco.debug.discoGraph"?: string;
+
+    /** List of Polyominoes */
+    "elk.disco.debug.discoPolys"?: string;
+
+    /** Edge Thickness */
+    "elk.edge.thickness"?: string;
+
+    /** Edge Type */
+    "elk.edge.type"?: string;
+
+    /** Inline Edge Labels */
+    "elk.edgeLabels.inline"?: string;
+
+    /** Edge Label Placement */
+    "elk.edgeLabels.placement"?: string;
+
+    /** Edge Routing */
+    "elk.edgeRouting"?: string;
+
+    /** Expand Nodes */
+    "elk.expandNodes"?: string;
+
+    /** Font Name */
+    "elk.font.name"?: string;
+
+    /** Font Size */
+    "elk.font.size"?: string;
+
+    /** Iterations */
+    "elk.force.iterations"?: string;
+
+    /** Force Model */
+    "elk.force.model"?: string;
+
+    /** Eades Repulsion */
+    "elk.force.repulsion"?: string;
+
+    /** Repulsive Power */
+    "elk.force.repulsivePower"?: string;
+
+    /** FR Temperature */
+    "elk.force.temperature"?: string;
+
+    /** Adapt Port Positions */
+    "elk.graphviz.adaptPortPositions"?: string;
+
+    /** Concentrate Edges */
+    "elk.graphviz.concentrate"?: string;
+
+    /** Epsilon */
+    "elk.graphviz.epsilon"?: string;
+
+    /** Iterations Factor */
+    "elk.graphviz.iterationsFactor"?: string;
+
+    /** Label Angle */
+    "elk.graphviz.labelAngle"?: string;
+
+    /** Label Distance */
+    "elk.graphviz.labelDistance"?: string;
+
+    /** Layer Spacing Factor */
+    "elk.graphviz.layerSpacingFactor"?: string;
+
+    /** Max. Iterations */
+    "elk.graphviz.maxiter"?: string;
+
+    /** Distance Model */
+    "elk.graphviz.neatoModel"?: string;
+
+    /** Overlap Removal */
+    "elk.graphviz.overlapMode"?: string;
+
+    /** Hierarchy Handling (Graphviz Dot) */
+    "elk.hierarchyHandling"?: string;
+
+    /** Hypernode */
+    "elk.hypernode"?: string;
+
+    /** Activate Inside Self Loops */
+    "elk.insideSelfLoops.activate"?: string;
+
+    /** Inside Self Loop */
+    "elk.insideSelfLoops.yo"?: string;
+
+    /** Interactive */
+    "elk.interactive"?: string;
+
+    /** interactive Layout */
+    "elk.interactiveLayout"?: string;
+
+    /** Edge Coords */
+    "elk.json.edgeCoords"?: string;
+
+    /** Shape Coords */
+    "elk.json.shapeCoords"?: string;
+
+    /** Junction Points */
+    "elk.junctionPoints"?: string;
+
+    /** Label Manager */
+    "elk.labelManager"?: string;
+
+    /** Label Manager */
+    "elk.labels.labelManager"?: string;
+
+    /** Allow Non-Flow Ports To Switch Sides */
+    "elk.layered.allowNonFlowPortsToSwitchSides"?: string;
+
+    /** Connected Components Compaction */
+    "elk.layered.compaction.connectedComponents"?: string;
+
+    /** Post Compaction Constraint Calculation */
+    "elk.layered.compaction.postCompaction.constraints"?: string;
+
+    /** Post Compaction Strategy */
+    "elk.layered.compaction.postCompaction.strategy"?: string;
+
+    /** Consider Model Order for Components */
+    "elk.layered.considerModelOrder.components"?: string;
+
+    /** Crossing Counter Node Order Influence */
+    "elk.layered.considerModelOrder.crossingCounterNodeInfluence"?: string;
+
+    /** Crossing Counter Port Order Influence */
+    "elk.layered.considerModelOrder.crossingCounterPortInfluence"?: string;
+
+    /** Cycle Breaking Group Ordering Strategy */
+    "elk.layered.considerModelOrder.groupModelOrder.cbGroupOrderStrategy"?: string;
+
+    /** Cycle Breaking Preferred Source Id */
+    "elk.layered.considerModelOrder.groupModelOrder.cbPreferredSourceId"?: string;
+
+    /** Cycle Breaking Preferred Target Id */
+    "elk.layered.considerModelOrder.groupModelOrder.cbPreferredTargetId"?: string;
+
+    /** Crossing Minimization Enforced Group Orders */
+    "elk.layered.considerModelOrder.groupModelOrder.cmEnforcedGroupOrders"?: string;
+
+    /** Crossing Minimization Group Ordering Strategy */
+    "elk.layered.considerModelOrder.groupModelOrder.cmGroupOrderStrategy"?: string;
+
+    /** Group ID of the Node Type */
+    "elk.layered.considerModelOrder.groupModelOrder.componentGroupId"?: string;
+
+    /** Group ID of the Node Type */
+    "elk.layered.considerModelOrder.groupModelOrder.crossingMinimizationId"?: string;
+
+    /** Group ID of the Node Type */
+    "elk.layered.considerModelOrder.groupModelOrder.cycleBreakingId"?: string;
+
+    /** Long Edge Ordering Strategy */
+    "elk.layered.considerModelOrder.longEdgeStrategy"?: string;
+
+    /** No Model Order */
+    "elk.layered.considerModelOrder.noModelOrder"?: string;
+
+    /** Consider Port Order */
+    "elk.layered.considerModelOrder.portModelOrder"?: string;
+
+    /** Consider Model Order */
+    "elk.layered.considerModelOrder.strategy"?: string;
+
+    /** Force Node Model Order */
+    "elk.layered.crossingMinimization.forceNodeModelOrder"?: string;
+
+    /** Greedy Switch Activation Threshold */
+    "elk.layered.crossingMinimization.greedySwitch.activationThreshold"?: string;
+
+    /** Greedy Switch Crossing Minimization */
+    "elk.layered.crossingMinimization.greedySwitch.type"?: string;
+
+    /** Greedy Switch Crossing Minimization (hierarchical) */
+    "elk.layered.crossingMinimization.greedySwitchHierarchical.type"?: string;
+
+    /** Hierarchical Sweepiness */
+    "elk.layered.crossingMinimization.hierarchicalSweepiness"?: string;
+
+    /** In Layer Predecessor of */
+    "elk.layered.crossingMinimization.inLayerPredOf"?: string;
+
+    /** In Layer Successor of */
+    "elk.layered.crossingMinimization.inLayerSuccOf"?: string;
+
+    /** Position Choice Constraint */
+    "elk.layered.crossingMinimization.positionChoiceConstraint"?: string;
+
+    /** Position ID */
+    "elk.layered.crossingMinimization.positionId"?: string;
+
+    /** Semi-Interactive Crossing Minimization */
+    "elk.layered.crossingMinimization.semiInteractive"?: string;
+
+    /** Crossing Minimization Strategy */
+    "elk.layered.crossingMinimization.strategy"?: string;
+
+    /** Cycle Breaking Strategy */
+    "elk.layered.cycleBreaking.strategy"?: string;
+
+    /** Direction Congruency */
+    "elk.layered.directionCongruency"?: string;
+
+    /** Edge Center Label Placement Strategy */
+    "elk.layered.edgeLabels.centerLabelPlacementStrategy"?: string;
+
+    /** Edge Label Side Selection */
+    "elk.layered.edgeLabels.sideSelection"?: string;
+
+    /** Sloped Edge Zone Width */
+    "elk.layered.edgeRouting.polyline.slopedEdgeZoneWidth"?: string;
+
+    /** Self-Loop Distribution */
+    "elk.layered.edgeRouting.selfLoopDistribution"?: string;
+
+    /** Self-Loop Ordering */
+    "elk.layered.edgeRouting.selfLoopOrdering"?: string;
+
+    /** Spline Routing Mode */
+    "elk.layered.edgeRouting.splines.mode"?: string;
+
+    /** Sloppy Spline Layer Spacing Factor */
+    "elk.layered.edgeRouting.splines.sloppy.layerSpacingFactor"?: string;
+
+    /** Feedback Edges */
+    "elk.layered.feedbackEdges"?: string;
+
+    /** Generate Position and Layer IDs */
+    "elk.layered.generatePositionAndLayerIds"?: string;
+
+    /** High Degree Node Threshold */
+    "elk.layered.highDegreeNodes.threshold"?: string;
+
+    /** High Degree Node Treatment */
+    "elk.layered.highDegreeNodes.treatment"?: string;
+
+    /** High Degree Node Maximum Tree Height */
+    "elk.layered.highDegreeNodes.treeHeight"?: string;
+
+    /** Interactive Reference Point */
+    "elk.layered.interactiveReferencePoint"?: string;
+
+    /** Layer Bound */
+    "elk.layered.layering.coffmanGraham.layerBound"?: string;
+
+    /** Layer Choice Constraint */
+    "elk.layered.layering.layerChoiceConstraint"?: string;
+
+    /** Layer Constraint */
+    "elk.layered.layering.layerConstraint"?: string;
+
+    /** Layer ID */
+    "elk.layered.layering.layerId"?: string;
+
+    /** Upper Bound On Width [MinWidth Layerer] */
+    "elk.layered.layering.minWidth.upperBoundOnWidth"?: string;
+
+    /** Upper Layer Estimation Scaling Factor [MinWidth Layerer] */
+    "elk.layered.layering.minWidth.upperLayerEstimationScalingFactor"?: string;
+
+    /** Max Node Promotion Iterations */
+    "elk.layered.layering.nodePromotion.maxIterations"?: string;
+
+    /** Node Promotion Strategy */
+    "elk.layered.layering.nodePromotion.strategy"?: string;
+
+    /** Node Layering Strategy */
+    "elk.layered.layering.strategy"?: string;
+
+    /** Unzipping Layer Split */
+    "elk.layered.layerUnzipping.layerSplit"?: string;
+
+    /** Minimize Edge Length Heuristic */
+    "elk.layered.layerUnzipping.minimizeEdgeLength"?: string;
+
+    /** Reset Alternation on Long Edges */
+    "elk.layered.layerUnzipping.resetOnLongEdges"?: string;
+
+    /** Layer Unzipping Strategy */
+    "elk.layered.layerUnzipping.strategy"?: string;
+
+    /** Merge Edges */
+    "elk.layered.mergeEdges"?: string;
+
+    /** Merge Hierarchy-Crossing Edges */
+    "elk.layered.mergeHierarchyEdges"?: string;
+
+    /** BK Edge Straightening */
+    "elk.layered.nodePlacement.bk.edgeStraightening"?: string;
+
+    /** BK Fixed Alignment */
+    "elk.layered.nodePlacement.bk.fixedAlignment"?: string;
+
+    /** Favor Straight Edges Over Balancing */
+    "elk.layered.nodePlacement.favorStraightEdges"?: string;
+
+    /** Linear Segments Deflection Dampening */
+    "elk.layered.nodePlacement.linearSegments.deflectionDampening"?: string;
+
+    /** Node Flexibility */
+    "elk.layered.nodePlacement.networkSimplex.nodeFlexibility"?: string;
+
+    /** Node Flexibility Default */
+    "elk.layered.nodePlacement.networkSimplex.nodeFlexibility.default"?: string;
+
+    /** Node Placement Strategy */
+    "elk.layered.nodePlacement.strategy"?: string;
+
+    /** Port Sorting Strategy */
+    "elk.layered.portSortingStrategy"?: string;
+
+    /** Direction Priority */
+    "elk.layered.priority.direction"?: string;
+
+    /** Shortness Priority (ELK Layered) */
+    "elk.layered.priority.shortness"?: string;
+
+    /** Straightness Priority */
+    "elk.layered.priority.straightness"?: string;
+
+    /** Spacing Base Value */
+    "elk.layered.spacing.baseValue"?: string;
+
+    /** Edge Edge Between Layer Spacing */
+    "elk.layered.spacing.edgeEdgeBetweenLayers"?: string;
+
+    /** Edge Node Between Layers Spacing */
+    "elk.layered.spacing.edgeNodeBetweenLayers"?: string;
+
+    /** Node Node Between Layers Spacing */
+    "elk.layered.spacing.nodeNodeBetweenLayers"?: string;
+
+    /** Thoroughness */
+    "elk.layered.thoroughness"?: string;
+
+    /** Add Unnecessary Bendpoints */
+    "elk.layered.unnecessaryBendpoints"?: string;
+
+    /** Additional Wrapped Edges Spacing */
+    "elk.layered.wrapping.additionalEdgeSpacing"?: string;
+
+    /** Correction Factor for Wrapping */
+    "elk.layered.wrapping.correctionFactor"?: string;
+
+    /** Manually Specified Cuts */
+    "elk.layered.wrapping.cutting.cuts"?: string;
+
+    /** MSD Freedom */
+    "elk.layered.wrapping.cutting.msd.freedom"?: string;
+
+    /** Cutting Strategy */
+    "elk.layered.wrapping.cutting.strategy"?: string;
+
+    /** Distance Penalty When Improving Cuts */
+    "elk.layered.wrapping.multiEdge.distancePenalty"?: string;
+
+    /** Improve Cuts */
+    "elk.layered.wrapping.multiEdge.improveCuts"?: string;
+
+    /** Improve Wrapped Edges */
+    "elk.layered.wrapping.multiEdge.improveWrappedEdges"?: string;
+
+    /** Graph Wrapping Strategy */
+    "elk.layered.wrapping.strategy"?: string;
+
+    /** Valid Indices for Wrapping */
+    "elk.layered.wrapping.validify.forbiddenIndices"?: string;
+
+    /** Validification Strategy */
+    "elk.layered.wrapping.validify.strategy"?: string;
+
+    /** Layout Ancestors */
+    "elk.layoutAncestors"?: string;
+
+    /** Margins */
+    "elk.margins"?: string;
+
+    /** Maximal Animation Time */
+    "elk.maxAnimTime"?: string;
+
+    /** Minimal Animation Time */
+    "elk.minAnimTime"?: string;
+
+    /** Position Constraint */
+    "elk.mrtree.compaction"?: string;
+
+    /** Edge End Texture Length */
+    "elk.mrtree.edgeEndTextureLength"?: string;
+
+    /** Edge Routing Mode */
+    "elk.mrtree.edgeRoutingMode"?: string;
+
+    /** Position Constraint */
+    "elk.mrtree.positionConstraint"?: string;
+
+    /** Search Order */
+    "elk.mrtree.searchOrder"?: string;
+
+    /** Tree Level */
+    "elk.mrtree.treeLevel"?: string;
+
+    /** Weighting of Nodes */
+    "elk.mrtree.weighting"?: string;
+
+    /** Node Label Padding */
+    "elk.nodeLabels.padding"?: string;
+
+    /** Node Label Placement */
+    "elk.nodeLabels.placement"?: string;
+
+    /** Node Size Constraints */
+    "elk.nodeSize.constraints"?: string;
+
+    /** Fixed Graph Size */
+    "elk.nodeSize.fixedGraphSize"?: string;
+
+    /** Node Size Minimum */
+    "elk.nodeSize.minimum"?: string;
+
+    /** Node Size Options */
+    "elk.nodeSize.options"?: string;
+
+    /** No Layout */
+    "elk.noLayout"?: string;
+
+    /** Omit Node Micro Layout */
+    "elk.omitNodeMicroLayout"?: string;
+
+    /** Upper limit for iterations of overlap removal */
+    "elk.overlapRemoval.maxIterations"?: string;
+
+    /** Whether to run a supplementary scanline overlap check. */
+    "elk.overlapRemoval.runScanline"?: string;
+
+    /** Padding */
+    "elk.padding"?: string;
+
+    /** Layout Partitioning */
+    "elk.partitioning.activate"?: string;
+
+    /** Layout Partition */
+    "elk.partitioning.partition"?: string;
+
+    /** Fill Polyominoes */
+    "elk.polyomino.fill"?: string;
+
+    /** Polyomino Primary Sorting Criterion */
+    "elk.polyomino.highLevelSort"?: string;
+
+    /** Polyomino Secondary Sorting Criterion */
+    "elk.polyomino.lowLevelSort"?: string;
+
+    /** Polyomino Traversal Strategy */
+    "elk.polyomino.traversalStrategy"?: string;
+
+    /** Port Anchor Offset */
+    "elk.port.anchor"?: string;
+
+    /** Port Border Offset */
+    "elk.port.borderOffset"?: string;
+
+    /** Port Index */
+    "elk.port.index"?: string;
+
+    /** Port Side */
+    "elk.port.side"?: string;
+
+    /** Port Alignment */
+    "elk.portAlignment.default"?: string;
+
+    /** Port Alignment (East) */
+    "elk.portAlignment.east"?: string;
+
+    /** Port Alignment (North) */
+    "elk.portAlignment.north"?: string;
+
+    /** Port Alignment (South) */
+    "elk.portAlignment.south"?: string;
+
+    /** Port Alignment (West) */
+    "elk.portAlignment.west"?: string;
+
+    /** Port Constraints */
+    "elk.portConstraints"?: string;
+
+    /** Port Labels Next to Port */
+    "elk.portLabels.nextToPortIfPossible"?: string;
+
+    /** Port Label Placement */
+    "elk.portLabels.placement"?: string;
+
+    /** Treat Port Labels as Group */
+    "elk.portLabels.treatAsGroup"?: string;
+
+    /** Position */
+    "elk.position"?: string;
+
+    /** Priority (ELK Mr. Tree) */
+    "elk.priority"?: string;
+
+    /** Root node for spanning tree construction */
+    "elk.processingOrder.preferredRoot"?: string;
+
+    /** Root selection for spanning tree */
+    "elk.processingOrder.rootSelection"?: string;
+
+    /** Cost Function for Spanning Tree */
+    "elk.processingOrder.spanningTreeCostFunction"?: string;
+
+    /** Tree Construction Strategy */
+    "elk.processingOrder.treeConstruction"?: string;
+
+    /** Progress Bar */
+    "elk.progressBar"?: string;
+
+    /** Center On Root */
+    "elk.radial.centerOnRoot"?: string;
+
+    /** Compaction Step Size */
+    "elk.radial.compactionStepSize"?: string;
+
+    /** Compaction */
+    "elk.radial.compactor"?: string;
+
+    /** Translation Optimization */
+    "elk.radial.optimizationCriteria"?: string;
+
+    /** Order ID */
+    "elk.radial.orderId"?: string;
+
+    /** Radius */
+    "elk.radial.radius"?: string;
+
+    /** Rotate */
+    "elk.radial.rotate"?: string;
+
+    /** Additional Wedge Space */
+    "elk.radial.rotation.computeAdditionalWedgeSpace"?: string;
+
+    /** Outgoing Edge Angles */
+    "elk.radial.rotation.outgoingEdgeAngles"?: string;
+
+    /** Target Angle */
+    "elk.radial.rotation.targetAngle"?: string;
+
+    /** Sorter */
+    "elk.radial.sorter"?: string;
+
+    /** Annulus Wedge Criteria */
+    "elk.radial.wedgeCriteria"?: string;
+
+    /** Randomization Seed */
+    "elk.randomSeed"?: string;
+
+    /** Current position of a node in the order of nodes */
+    "elk.rectpacking.currentPosition"?: string;
+
+    /** Desired index of node */
+    "elk.rectpacking.desiredPosition"?: string;
+
+    /** In new Row */
+    "elk.rectpacking.inNewRow"?: string;
+
+    /** Order nodes by height */
+    "elk.rectpacking.orderBySize"?: string;
+
+    /** Compaction iterations */
+    "elk.rectpacking.packing.compaction.iterations"?: string;
+
+    /** Row Height Reevaluation */
+    "elk.rectpacking.packing.compaction.rowHeightReevaluation"?: string;
+
+    /** Compaction Strategy */
+    "elk.rectpacking.packing.strategy"?: string;
+
+    /** Try box layout first */
+    "elk.rectpacking.trybox"?: string;
+
+    /** White Space Approximation Strategy */
+    "elk.rectpacking.whiteSpaceElimination.strategy"?: string;
+
+    /** Shift Last Placed. */
+    "elk.rectpacking.widthApproximation.lastPlaceShift"?: string;
+
+    /** Optimization Goal */
+    "elk.rectpacking.widthApproximation.optimizationGoal"?: string;
+
+    /** Width Approximation Strategy */
+    "elk.rectpacking.widthApproximation.strategy"?: string;
+
+    /** Target Width */
+    "elk.rectpacking.widthApproximation.targetWidth"?: string;
+
+    /** Resolved Layout Algorithm */
+    "elk.resolvedAlgorithm"?: string;
+
+    /** Scale Factor */
+    "elk.scaleFactor"?: string;
+
+    /** Separate Connected Components */
+    "elk.separateConnectedComponents"?: string;
+
+    /** Softwrapping Fuzziness */
+    "elk.softwrappingFuzziness"?: string;
+
+    /** Comment Comment Spacing */
+    "elk.spacing.commentComment"?: string;
+
+    /** Comment Node Spacing */
+    "elk.spacing.commentNode"?: string;
+
+    /** Components Spacing */
+    "elk.spacing.componentComponent"?: string;
+
+    /** Edge Spacing */
+    "elk.spacing.edgeEdge"?: string;
+
+    /** Edge Label Spacing */
+    "elk.spacing.edgeLabel"?: string;
+
+    /** Edge Node Spacing */
+    "elk.spacing.edgeNode"?: string;
+
+    /** Individual Spacing (ELK Layered) */
+    "elk.spacing.individual"?: string;
+
+    /** Label Spacing */
+    "elk.spacing.labelLabel"?: string;
+
+    /** Label Node Spacing */
+    "elk.spacing.labelNode"?: string;
+
+    /** Horizontal spacing between Label and Port */
+    "elk.spacing.labelPortHorizontal"?: string;
+
+    /** Vertical spacing between Label and Port */
+    "elk.spacing.labelPortVertical"?: string;
+
+    /** Node Spacing */
+    "elk.spacing.nodeNode"?: string;
+
+    /** Node Self Loop Spacing */
+    "elk.spacing.nodeSelfLoop"?: string;
+
+    /** Port Spacing */
+    "elk.spacing.portPort"?: string;
+
+    /** Additional Port Space */
+    "elk.spacing.portsSurrounding"?: string;
+
+    /** Desired Edge Length */
+    "elk.stress.desiredEdgeLength"?: string;
+
+    /** Layout Dimension */
+    "elk.stress.dimension"?: string;
+
+    /** Stress Epsilon */
+    "elk.stress.epsilon"?: string;
+
+    /** Fixed Position */
+    "elk.stress.fixed"?: string;
+
+    /** Iteration Limit */
+    "elk.stress.iterationLimit"?: string;
+
+    /** Structure Extraction Strategy */
+    "elk.structure.structureExtractionStrategy"?: string;
+
+    /** Topdown Hierarchical Node Aspect Ratio */
+    "elk.topdown.hierarchicalNodeAspectRatio"?: string;
+
+    /** Topdown Hierarchical Node Width */
+    "elk.topdown.hierarchicalNodeWidth"?: string;
+
+    /** Topdown Node Type */
+    "elk.topdown.nodeType"?: string;
+
+    /** Topdown Scale Cap */
+    "elk.topdown.scaleCap"?: string;
+
+    /** Topdown Scale Factor */
+    "elk.topdown.scaleFactor"?: string;
+
+    /** Topdown Size Approximator */
+    "elk.topdown.sizeApproximator"?: string;
+
+    /** Number of size categories */
+    "elk.topdown.sizeCategories"?: string;
+
+    /** Weight of a node containing children for determining the graph size */
+    "elk.topdown.sizeCategoriesHierarchicalNodeWeight"?: string;
+
+    /** Topdown Layout */
+    "elk.topdownLayout"?: string;
+
+    /** Node arrangement strategy */
+    "elk.topdownpacking.nodeArrangement.strategy"?: string;
+
+    /** Whitespace elimination strategy */
+    "elk.topdownpacking.whitespaceElimination.strategy"?: string;
+
+    /** Underlying Layout Algorithm */
+    "elk.underlyingLayoutAlgorithm"?: string;
+
+    /** Validate Graph */
+    "elk.validateGraph"?: string;
+
+    /** Validate Options */
+    "elk.validateOptions"?: string;
+
+    /** Consider node model order */
+    "elk.vertiflex.considerNodeModelOrder"?: string;
+
+    /** Layer distance */
+    "elk.vertiflex.layerDistance"?: string;
+
+    /** Edge layout strategy */
+    "elk.vertiflex.layoutStrategy"?: string;
+
+    /** Fixed vertical position */
+    "elk.vertiflex.verticalConstraint"?: string;
+
+    /** Zoom to Fit */
+    "elk.zoomToFit"?: string;
+
+    [key: string]: any;
 }
 
 export interface ElkPoint {

--- a/typings/elk-api.d.ts
+++ b/typings/elk-api.d.ts
@@ -12,841 +12,837 @@
  * ELK Layout Options with descriptions based on https://www.eclipse.org/elk/reference/options.html
  */
 export interface LayoutOptions {
-    /** Angle Penalty */
+    /** This penalty is applied in its full amount to tight acute bends in the connector path. A smaller portion of the penalty is applied for slight bends, i.e., where the bend is close to 180 degrees. This is useful for polyline routing where there is some evidence that tighter corners are worse for readability, but that slight bends might not be so bad, especially when smoothed by curves. */
     "elk.alg.libavoid.anglePenalty"?: string;
 
-    /** Spacing between pairs of ports of the same node */
+    /** Spacing between pairs of ports of the same node. */
     "elk.spacing.portConnection"?: string;
 
-    /** Cluster Crossing Penalty */
+    /** This penalty is applied whenever a connector path crosses a cluster boundary. */
     "elk.alg.libavoid.clusterCrossingPenalty"?: string;
 
-    /** Crossing Penalty */
+    /** This penalty is applied whenever a connector path crosses another connector path. It takes shared paths into consideration and the penalty is only applied if there is an actual crossing. */
     "elk.alg.libavoid.crossingPenalty"?: string;
 
-    /** Enable Hyperedges From Common Source */
+    /** This option enables a post-processing step that creates hyperedges for all edges with the same source. Be aware that this step will significantly decrease performance. */
     "elk.alg.libavoid.enableHyperedgesFromCommonSource"?: string;
 
-    /** Fixed Shared Path Penalty */
+    /** This penalty is applied whenever a connector path shares some segments with an immovable portion of an existing connector route (such as the first or last segment of a connector). */
     "elk.alg.libavoid.fixedSharedPathPenalty"?: string;
 
-    /** Ideal Nudging Distance */
+    /** This parameter defines the spacing distance that will be used for nudging apart overlapping corners and line segments of connectors. */
     "elk.alg.libavoid.idealNudgingDistance"?: string;
 
-    /** Improve Hyperedge Routes Add/Delete */
+    /** This option causes hyperedge routes to be locally improved fixing obviously bad paths. It can cause junctions and connectors to be added or removed from hyperedges. As part of this process libavoid will effectively move junctions by setting new ideal positions for each remaining or added junction. If set, this option overrides the improveHyperedgeRoutesMovingJunctions option. */
     "elk.alg.libavoid.improveHyperedgeRoutesMovingAddingAndDeletingJunctions"?: string;
 
-    /** Improve Hyperedge Routes */
+    /** This option causes hyperedge routes to be locally improved fixing obviously bad paths. As part of this process libavoid will effectively move junctions, setting new ideal positions for each junction. */
     "elk.alg.libavoid.improveHyperedgeRoutesMovingJunctions"?: string;
 
-    /** Marks a node as a cluster */
+    /** This option marks a node as a cluster, resulting in its children being handled as relative to the graph itself while the marked node is only added as a cluster. Note that clusters are experimental and can therefore have a negative impact on performance. The cluster node cannot have: - clusters as children - outgoing or incoming connections (directly to the node) - ports Edges into or out of the cluster must be added across the cluster’s borders, without the use of hierarchical ports. */
     "elk.alg.libavoid.isCluster"?: string;
 
-    /** Nudge Orthogonal Segments */
+    /** This option causes the final segments of connectors, which are attached to shapes, to be nudged apart. Usually these segments are fixed, since they are considered to be attached to ports. */
     "elk.alg.libavoid.nudgeOrthogonalSegmentsConnectedToShapes"?: string;
 
-    /** Nudge Orthogonal Touching Colinear Segments */
+    /** This option can be used to control whether colinear line segments that touch just at their ends will be nudged apart. The overlap will usually be resolved in the other dimension, so this is not usually required. */
     "elk.alg.libavoid.nudgeOrthogonalTouchingColinearSegments"?: string;
 
-    /** Nudge Shared Paths With Common Endpoint */
+    /** This option determines whether intermediate segments of connectors that are attached to common endpoints will be nudged apart. Usually these segments get nudged apart, but you may want to turn this off if you would prefer that entire shared paths terminating at a common end point should overlap. */
     "elk.alg.libavoid.nudgeSharedPathsWithCommonEndPoint"?: string;
 
-    /** Penalise Orthogonal Shared Paths */
+    /** This option penalises and attempts to reroute orthogonal shared connector paths terminating at a common junction or shape connection pin. When multiple connector paths enter or leave the same side of a junction (or shape pin), the router will attempt to reroute these to different sides of the junction or different shape pins. This option depends on the fixedSharedPathPenalty penalty having been set. */
     "elk.alg.libavoid.penaliseOrthogonalSharedPathsAtConnEnds"?: string;
 
-    /** Perform Unifying Nudging Preprocessing */
+    /** This option can be used to control whether the router performs a preprocessing step before orthogonal nudging where is tries to unify segments and centre them in free space. This generally results in better quality ordering and nudging. */
     "elk.alg.libavoid.performUnifyingNudgingPreprocessingStep"?: string;
 
-    /** Port Direction Penalty */
+    /** This penalty is applied to port selection choice when the other end of the connector being routed does not appear in any of the 90 degree visibility cones centered on the visibility directions for the port. */
     "elk.alg.libavoid.portDirectionPenalty"?: string;
 
-    /** Default process timeout. */
+    /** Default timeout for waiting for the libavoid server to give some output. This option is read from the root of the graph. */
     "elk.alg.libavoid.processTimeout"?: string;
 
-    /** Reverse Direction Penalty */
+    /** This penalty is applied whenever a connector path travels in the direction opposite of the destination from the source endpoint. By default this penalty is set to zero. This shouldn’t be needed in most cases but can be useful if you use penalties such as crossingPenalty which cause connectors to loop around obstacles. */
     "elk.alg.libavoid.reverseDirectionPenalty"?: string;
 
-    /** Segment Penalty */
+    /** This penalty is applied for each segment in the connector path beyond the first. This should always normally be set when doing orthogonal routing to prevent step-like connector paths. */
     "elk.alg.libavoid.segmentPenalty"?: string;
 
-    /** Shape Buffer Distance */
+    /** This parameter defines the spacing distance that will be added to the sides of each shape when determining obstacle sizes for routing. This controls how closely connectors pass shapes, and can be used to prevent connectors overlapping with shape boundaries. */
     "elk.alg.libavoid.shapeBufferDistance"?: string;
 
-    /** Layout Algorithm */
+    /** Select a specific layout algorithm. */
     "elk.algorithm"?: string;
 
-    /** Alignment */
+    /** Alignment of the selected node relative to other nodes; the exact meaning depends on the used algorithm. */
     "elk.alignment"?: string;
 
-    /** Animate */
+    /** Whether the shift from the old layout to the new computed layout shall be animated. */
     "elk.animate"?: string;
 
-    /** Animation Time Factor */
+    /** Factor for computation of animation time. The higher the value, the longer the animation time. If the value is 0, the resulting time is always equal to the minimum defined by ‘Minimal Animation Time’. */
     "elk.animTimeFactor"?: string;
 
-    /** Aspect Ratio */
+    /** The desired aspect ratio of the drawing, that is the quotient of width by height. */
     "elk.aspectRatio"?: string;
 
-    /** Bend Points */
+    /** A fixed list of bend points for the edge. This is used by the ‘Fixed Layout’ algorithm to specify a pre-defined routing for an edge. The vector chain must include the source point, any bend points, and the target point, so it must have at least two points. */
     "elk.bendPoints"?: string;
 
-    /** Box Layout Mode */
+    /** Configures the packing mode used by the {@link BoxLayoutProvider}. If SIMPLE is not required (neither priorities are used nor the interactive mode), GROUP_DEC can improve the packing and decrease the area. GROUP_MIXED and GROUP_INC may, in very specific scenarios, work better. */
     "elk.box.packingMode"?: string;
 
-    /** Child Area Height */
+    /** The height of the area occupied by the laid out children of a node. */
     "elk.childAreaHeight"?: string;
 
-    /** Child Area Width */
+    /** The width of the area occupied by the laid out children of a node. */
     "elk.childAreaWidth"?: string;
 
-    /** Comment Box */
+    /** Whether the node should be regarded as a comment box instead of a regular node. In that case its placement should be similar to how labels are handled. Any edges incident to a comment box specify to which graph elements the comment is related. */
     "elk.commentBox"?: string;
 
-    /** Compaction Strategy */
+    /** This option defines how the compaction is applied. */
     "elk.compaction.compactionStrategy"?: string;
 
-    /** Orthogonal Compaction */
+    /** Restricts the translation of nodes to orthogonal directions in the compaction phase. */
     "elk.compaction.orthogonal"?: string;
 
-    /** Content Alignment */
+    /** Specifies how the content of a node are aligned. Each node can individually control the alignment of its contents. I.e. if a node should be aligned top left in its parent node, the parent node should specify that option. */
     "elk.contentAlignment"?: string;
 
-    /** Debug Mode */
+    /** Whether additional debug information shall be generated. */
     "elk.debugMode"?: string;
 
-    /** Direction */
+    /** Overall direction of edges: horizontal (right / left) or vertical (down / up). */
     "elk.direction"?: string;
 
-    /** Connected Components Layout Algorithm */
+    /** A layout algorithm that is to be applied to each connected component before the components themselves are compacted. If unspecified, the positions of the components’ nodes are not altered. */
     "elk.disco.componentCompaction.componentLayoutAlgorithm"?: string;
 
-    /** Connected Components Compaction Strategy */
+    /** Strategy for packing different connected components in order to save space and enhance readability of a graph. */
     "elk.disco.componentCompaction.strategy"?: string;
 
-    /** DCGraph */
+    /** Access to the DCGraph is intended for the debug view, */
     "elk.disco.debug.discoGraph"?: string;
 
-    /** List of Polyominoes */
+    /** Access to the polyominoes is intended for the debug view, */
     "elk.disco.debug.discoPolys"?: string;
 
-    /** Edge Thickness */
+    /** The thickness of an edge. This is a hint on the line width used to draw an edge, possibly requiring more space to be reserved for it. */
     "elk.edge.thickness"?: string;
 
-    /** Edge Type */
+    /** The type of an edge. This is usually used for UML class diagrams, where associations must be handled differently from generalizations. */
     "elk.edge.type"?: string;
 
-    /** Inline Edge Labels */
+    /** If true, an edge label is placed directly on its edge. May only apply to center edge labels. This kind of label placement is only advisable if the label’s rendering is such that it is not crossed by its edge and thus stays legible. */
     "elk.edgeLabels.inline"?: string;
 
-    /** Edge Label Placement */
+    /** Gives a hint on where to put edge labels. */
     "elk.edgeLabels.placement"?: string;
 
-    /** Edge Routing */
+    /** What kind of edge routing style should be applied for the content of a parent node. Algorithms may also set this option to single edges in order to mark them as splines. The bend point list of edges with this option set to SPLINES must be interpreted as control points for a piecewise cubic spline. */
     "elk.edgeRouting"?: string;
 
-    /** Expand Nodes */
+    /** If active, nodes are expanded to fill the area of their parent. */
     "elk.expandNodes"?: string;
 
-    /** Font Name */
+    /** Font name used for a label. */
     "elk.font.name"?: string;
 
-    /** Font Size */
+    /** Font size used for a label. */
     "elk.font.size"?: string;
 
-    /** Iterations */
+    /** The number of iterations on the force model. */
     "elk.force.iterations"?: string;
 
-    /** Force Model */
+    /** Determines the model for force calculation. */
     "elk.force.model"?: string;
 
-    /** Eades Repulsion */
+    /** Factor for repulsive forces in Eades’ model. */
     "elk.force.repulsion"?: string;
 
-    /** Repulsive Power */
+    /** Determines how many bend points are added to the edge; such bend points are regarded as repelling particles in the force model */
     "elk.force.repulsivePower"?: string;
 
-    /** FR Temperature */
+    /** The temperature is used as a scaling factor for particle displacements. */
     "elk.force.temperature"?: string;
 
-    /** Adapt Port Positions */
+    /** Whether ports should be moved to the point where edges cross the node’s bounds. */
     "elk.graphviz.adaptPortPositions"?: string;
 
-    /** Concentrate Edges */
+    /** Merges multiedges into a single edge and causes partially parallel edges to share part of their paths. */
     "elk.graphviz.concentrate"?: string;
 
-    /** Epsilon */
+    /** Terminating condition. If the length squared of all energy gradients are less than epsilon, the algorithm stops. */
     "elk.graphviz.epsilon"?: string;
 
-    /** Iterations Factor */
+    /** Multiplicative scale factor for the maximal number of iterations used during crossing minimization, node ranking, and node positioning. */
     "elk.graphviz.iterationsFactor"?: string;
 
-    /** Label Angle */
+    /** Angle between head / tail positioned edge labels and the corresponding edge. */
     "elk.graphviz.labelAngle"?: string;
 
-    /** Label Distance */
+    /** Distance of head / tail positioned edge labels to the source or target node. */
     "elk.graphviz.labelDistance"?: string;
 
-    /** Layer Spacing Factor */
+    /** Factor for the spacing of different layers (ranks). */
     "elk.graphviz.layerSpacingFactor"?: string;
 
-    /** Max. Iterations */
+    /** The maximum number of iterations. */
     "elk.graphviz.maxiter"?: string;
 
-    /** Distance Model */
+    /** Specifies how the distance matrix is computed for the input graph. */
     "elk.graphviz.neatoModel"?: string;
 
-    /** Overlap Removal */
+    /** Determines if and how node overlaps should be removed. */
     "elk.graphviz.overlapMode"?: string;
 
-    /** Hierarchy Handling (Graphviz Dot) */
+    /** Determines whether separate layout runs are triggered for different compound nodes in a hierarchical graph. Setting a node’s hierarchy handling to INCLUDE_CHILDREN will lay out that node and all of its descendants in a single layout run, until a descendant is encountered which has its hierarchy handling set to SEPARATE_CHILDREN. In general, SEPARATE_CHILDREN will ensure that a new layout run is triggered for a node with that setting. Including multiple levels of hierarchy in a single layout run may allow cross-hierarchical edges to be laid out properly. If the root node is set to INHERIT (or not set at all), the default behavior is SEPARATE_CHILDREN. */
     "elk.hierarchyHandling"?: string;
 
-    /** Hypernode */
+    /** Whether the node should be handled as a hypernode. */
     "elk.hypernode"?: string;
 
-    /** Activate Inside Self Loops */
+    /** Whether this node allows to route self loops inside of it instead of around it. If set to true, this will make the node a compound node if it isn’t already, and will require the layout algorithm to support compound nodes with hierarchical ports. */
     "elk.insideSelfLoops.activate"?: string;
 
-    /** Inside Self Loop */
+    /** Whether a self loop should be routed inside a node instead of around that node. */
     "elk.insideSelfLoops.yo"?: string;
 
-    /** Interactive */
+    /** Whether the algorithm should be run in interactive mode for the content of a parent node. What this means exactly depends on how the specific algorithm interprets this option. Usually in the interactive mode algorithms try to modify the current layout as little as possible. */
     "elk.interactive"?: string;
 
-    /** interactive Layout */
+    /** Whether the graph should be changeable interactively and by setting constraints */
     "elk.interactiveLayout"?: string;
 
-    /** Edge Coords */
+    /** For layouts transferred into JSON graphs, specify the coordinate system to be used for edge route points and edge labels. */
     "elk.json.edgeCoords"?: string;
 
-    /** Shape Coords */
+    /** For layouts transferred into JSON graphs, specify the coordinate system to be used for nodes, ports, and labels of nodes and ports. */
     "elk.json.shapeCoords"?: string;
 
-    /** Junction Points */
+    /** This option is not used as option, but as output of the layout algorithms. It is attached to edges and determines the points where junction symbols should be drawn in order to represent hyperedges with orthogonal routing. Whether such points are computed depends on the chosen layout algorithm and edge routing style. The points are put into the vector chain with no specific order. */
     "elk.junctionPoints"?: string;
 
-    /** Label Manager */
+    /** Label managers can shorten labels upon a layout algorithm’s request. */
     "elk.labelManager"?: string;
 
-    /** Label Manager */
+    /** The label manager responsible for a given part of the graph. A label manager can either be attached to a compound node (in which case it is responsible for all labels inside) or to specific labels. The label manager can then be called by layout algorithms to modify labels that are too wide to try and shorten them to a given target width. */
     "elk.labels.labelManager"?: string;
 
-    /** Allow Non-Flow Ports To Switch Sides */
+    /** Specifies whether non-flow ports may switch sides if their node’s port constraints are either FIXED_SIDE or FIXED_ORDER. A non-flow port is a port on a side that is not part of the currently configured layout flow. For instance, given a left-to-right layout direction, north and south ports would be considered non-flow ports. Further note that the underlying criterium whether to switch sides or not solely relies on the minimization of edge crossings. Hence, edge length and other aesthetics criteria are not addressed. */
     "elk.layered.allowNonFlowPortsToSwitchSides"?: string;
 
-    /** Connected Components Compaction */
+    /** Tries to further compact components (disconnected sub-graphs). */
     "elk.layered.compaction.connectedComponents"?: string;
 
-    /** Post Compaction Constraint Calculation */
+    /** Specifies whether and how post-process compaction is applied. */
     "elk.layered.compaction.postCompaction.constraints"?: string;
 
-    /** Post Compaction Strategy */
+    /** Specifies whether and how post-process compaction is applied. */
     "elk.layered.compaction.postCompaction.strategy"?: string;
 
-    /** Consider Model Order for Components */
+    /** If set to NONE the usual ordering strategy (by cumulative node priority and size of nodes) is used. INSIDE_PORT_SIDES orders the components with external ports only inside the groups with the same port side. FORCE_MODEL_ORDER enforces the mode order on components. This option might produce bad alignments and sub optimal drawings in terms of used area since the ordering should be respected. */
     "elk.layered.considerModelOrder.components"?: string;
 
-    /** Crossing Counter Node Order Influence */
+    /** Indicates with what percentage (1 for 100%) violations of the node model order are weighted against the crossings e.g. a value of 0.5 means two model order violations are as important as on edge crossing. This allows some edge crossings in favor of preserving the model order. It is advised to set this value to a very small positive value (e.g. 0.001) to have minimal crossing and a optimal node order. Defaults to no influence (0). */
     "elk.layered.considerModelOrder.crossingCounterNodeInfluence"?: string;
 
-    /** Crossing Counter Port Order Influence */
+    /** Indicates with what percentage (1 for 100%) violations of the port model order are weighted against the crossings e.g. a value of 0.5 means two model order violations are as important as on edge crossing. This allows some edge crossings in favor of preserving the model order. It is advised to set this value to a very small positive value (e.g. 0.001) to have minimal crossing and a optimal port order. Defaults to no influence (0). */
     "elk.layered.considerModelOrder.crossingCounterPortInfluence"?: string;
 
-    /** Cycle Breaking Group Ordering Strategy */
+    /** Determines how to count ordering violations during cycle breaking. NONE: They do not count. ENFORCED: A group with a higher model order is before a node with a smaller. MODEL_ORDER: The model order counts instead of the model order group id ordering. */
     "elk.layered.considerModelOrder.groupModelOrder.cbGroupOrderStrategy"?: string;
 
-    /** Cycle Breaking Preferred Source Id */
+    /** The model order group id for which should be preferred as a source if possible. */
     "elk.layered.considerModelOrder.groupModelOrder.cbPreferredSourceId"?: string;
 
-    /** Cycle Breaking Preferred Target Id */
+    /** The model order group id for which should be preferred as a target if possible. */
     "elk.layered.considerModelOrder.groupModelOrder.cbPreferredTargetId"?: string;
 
-    /** Crossing Minimization Enforced Group Orders */
+    /** Holds all group ids which are enforcing their order during crossing minimization strategies. E.g. if only groups 2 and -1 (default) enforce their ordering. Other groups e.g. the group of timer nodes can be ordered arbitrarily if it helps and the mentioned groups may not change their order. */
     "elk.layered.considerModelOrder.groupModelOrder.cmEnforcedGroupOrders"?: string;
 
-    /** Crossing Minimization Group Ordering Strategy */
+    /** Determines how to count ordering violations during crossing minimization. NONE: They do not count. ENFORCED: A group with a lower id is before a group with a higher id. MODEL_ORDER: The model order counts instead of the model order group id ordering. */
     "elk.layered.considerModelOrder.groupModelOrder.cmGroupOrderStrategy"?: string;
 
-    /** Group ID of the Node Type */
+    /** Used to define partial ordering groups during component packing. A lower group id means that the group is sorted before other groups. A group model order of 0 is the default group. */
     "elk.layered.considerModelOrder.groupModelOrder.componentGroupId"?: string;
 
-    /** Group ID of the Node Type */
+    /** Used to define partial ordering groups during crossing minimization. A lower group id means that the group is sorted before other groups. A group model order of 0 is the default group. */
     "elk.layered.considerModelOrder.groupModelOrder.crossingMinimizationId"?: string;
 
-    /** Group ID of the Node Type */
+    /** Used to define partial ordering groups during cycle breaking. A lower group id means that the group is sorted before other groups. A group model order of 0 is the default group. */
     "elk.layered.considerModelOrder.groupModelOrder.cycleBreakingId"?: string;
 
-    /** Long Edge Ordering Strategy */
+    /** Indicates whether long edges are sorted under, over, or equal to nodes that have no connection to a previous layer in a left-to-right or right-to-left layout. Under and over changes to right and left in a vertical layout. */
     "elk.layered.considerModelOrder.longEdgeStrategy"?: string;
 
-    /** No Model Order */
+    /** Set on a node to not set a model order for this node even though it is a real node. */
     "elk.layered.considerModelOrder.noModelOrder"?: string;
 
-    /** Consider Port Order */
+    /** If disabled the port order of output ports is derived from the edge order and input ports are ordered by their incoming connections. If enabled all ports are ordered by the port model order. */
     "elk.layered.considerModelOrder.portModelOrder"?: string;
 
-    /** Consider Model Order */
+    /** Preserves the order of nodes and edges in the model file if this does not lead to additional edge crossings. Depending on the strategy this is not always possible since the node and edge order might be conflicting. */
     "elk.layered.considerModelOrder.strategy"?: string;
 
-    /** Force Node Model Order */
+    /** The node order given by the model does not change to produce a better layout. E.g. if node A is before node B in the model this is not changed during crossing minimization. This assumes that the node model order is already respected before crossing minimization. This can be achieved by setting considerModelOrder.strategy to NODES_AND_EDGES. */
     "elk.layered.crossingMinimization.forceNodeModelOrder"?: string;
 
-    /** Greedy Switch Activation Threshold */
+    /** By default it is decided automatically if the greedy switch is activated or not. The decision is based on whether the size of the input graph (without dummy nodes) is smaller than the value of this option. A ‘0’ enforces the activation. */
     "elk.layered.crossingMinimization.greedySwitch.activationThreshold"?: string;
 
-    /** Greedy Switch Crossing Minimization */
+    /** Greedy Switch strategy for crossing minimization. The greedy switch heuristic is executed after the regular crossing minimization as a post-processor. Note that if ‘hierarchyHandling’ is set to ‘INCLUDE_CHILDREN’, the ‘greedySwitchHierarchical.type’ option must be used. */
     "elk.layered.crossingMinimization.greedySwitch.type"?: string;
 
-    /** Greedy Switch Crossing Minimization (hierarchical) */
+    /** Activates the greedy switch heuristic in case hierarchical layout is used. The differences to the non-hierarchical case (see ‘greedySwitch.type’) are: 1) greedy switch is inactive by default, 3) only the option value set on the node at which hierarchical layout starts is relevant, and 2) if it’s activated by the user, it properly addresses hierarchy-crossing edges. */
     "elk.layered.crossingMinimization.greedySwitchHierarchical.type"?: string;
 
-    /** Hierarchical Sweepiness */
+    /** How likely it is to use cross-hierarchy (1) vs bottom-up (-1). */
     "elk.layered.crossingMinimization.hierarchicalSweepiness"?: string;
 
-    /** In Layer Predecessor of */
+    /** Allows to set a constraint which specifies of which node the current node is the predecessor. If set to ’s’ then the node is the predecessor of ’s’ and is in the same layer */
     "elk.layered.crossingMinimization.inLayerPredOf"?: string;
 
-    /** In Layer Successor of */
+    /** Allows to set a constraint which specifies of which node the current node is the successor. If set to ’s’ then the node is the successor of ’s’ and is in the same layer */
     "elk.layered.crossingMinimization.inLayerSuccOf"?: string;
 
-    /** Position Choice Constraint */
+    /** Allows to set a constraint regarding the position placement of a node in a layer. Assumed the layer in which the node placed includes n other nodes and i < n. If set to i, it expresses that the node should be placed at the i-th position. Should i>=n be true then the node is placed at the last position in the layer. Note that this option is not part of any of ELK Layered’s default configurations but is only evaluated as part of the InteractiveLayeredGraphVisitor, which must be applied manually or used via the `DiagramLayoutEngine. */
     "elk.layered.crossingMinimization.positionChoiceConstraint"?: string;
 
-    /** Position ID */
+    /** Position within a layer that was determined by ELK Layered for a node. This is only generated if interactiveLayot or generatePositionAndLayerIds is set. */
     "elk.layered.crossingMinimization.positionId"?: string;
 
-    /** Semi-Interactive Crossing Minimization */
+    /** Preserves the order of nodes within a layer but still minimizes crossings between edges connecting long edge dummies. Derives the desired order from positions specified by the ‘org.eclipse.elk.position’ layout option. Requires a crossing minimization strategy that is able to process ‘in-layer’ constraints. */
     "elk.layered.crossingMinimization.semiInteractive"?: string;
 
-    /** Crossing Minimization Strategy */
+    /** Strategy for crossing minimization. */
     "elk.layered.crossingMinimization.strategy"?: string;
 
-    /** Cycle Breaking Strategy */
+    /** Strategy for cycle breaking. Cycle breaking looks for cycles in the graph and determines which edges to reverse to break the cycles. Reversed edges will end up pointing to the opposite direction of regular edges (that is, reversed edges will point left if edges usually point right). */
     "elk.layered.cycleBreaking.strategy"?: string;
 
-    /** Direction Congruency */
+    /** Specifies how drawings of the same graph with different layout directions compare to each other: either a natural reading direction is preserved or the drawings are rotated versions of each other. */
     "elk.layered.directionCongruency"?: string;
 
-    /** Edge Center Label Placement Strategy */
+    /** Determines in which layer center labels of long edges should be placed. */
     "elk.layered.edgeLabels.centerLabelPlacementStrategy"?: string;
 
-    /** Edge Label Side Selection */
+    /** Method to decide on edge label sides. */
     "elk.layered.edgeLabels.sideSelection"?: string;
 
-    /** Sloped Edge Zone Width */
+    /** Width of the strip to the left and to the right of each layer where the polyline edge router is allowed to refrain from ensuring that edges are routed horizontally. This prevents awkward bend points for nodes that extent almost to the edge of their layer. */
     "elk.layered.edgeRouting.polyline.slopedEdgeZoneWidth"?: string;
 
-    /** Self-Loop Distribution */
+    /** Alter the distribution of the loops around the node. It only takes effect for PortConstraints.FREE. */
     "elk.layered.edgeRouting.selfLoopDistribution"?: string;
 
-    /** Self-Loop Ordering */
+    /** Alter the ordering of the loops they can either be stacked or sequenced. It only takes effect for PortConstraints.FREE. */
     "elk.layered.edgeRouting.selfLoopOrdering"?: string;
 
-    /** Spline Routing Mode */
+    /** Specifies the way control points are assembled for each individual edge. CONSERVATIVE ensures that edges are properly routed around the nodes but feels rather orthogonal at times. SLOPPY uses fewer control points to obtain curvier edge routes but may result in edges overlapping nodes. */
     "elk.layered.edgeRouting.splines.mode"?: string;
 
-    /** Sloppy Spline Layer Spacing Factor */
+    /** Spacing factor for routing area between layers when using sloppy spline routing. */
     "elk.layered.edgeRouting.splines.sloppy.layerSpacingFactor"?: string;
 
-    /** Feedback Edges */
+    /** Whether feedback edges should be highlighted by routing around the nodes. */
     "elk.layered.feedbackEdges"?: string;
 
-    /** Generate Position and Layer IDs */
+    /** If enabled position id and layer id are generated, which are usually only used internally when setting the interactiveLayout option. This option should be specified on the root node. */
     "elk.layered.generatePositionAndLayerIds"?: string;
 
-    /** High Degree Node Threshold */
+    /** Whether a node is considered to have a high degree. */
     "elk.layered.highDegreeNodes.threshold"?: string;
 
-    /** High Degree Node Treatment */
+    /** Makes room around high degree nodes to place leafs and trees. */
     "elk.layered.highDegreeNodes.treatment"?: string;
 
-    /** High Degree Node Maximum Tree Height */
+    /** Maximum height of a subtree connected to a high degree node to be moved to separate layers. */
     "elk.layered.highDegreeNodes.treeHeight"?: string;
 
-    /** Interactive Reference Point */
+    /** Determines which point of a node is considered by interactive layout phases. */
     "elk.layered.interactiveReferencePoint"?: string;
 
-    /** Layer Bound */
+    /** The maximum number of nodes allowed per layer. */
     "elk.layered.layering.coffmanGraham.layerBound"?: string;
 
-    /** Layer Choice Constraint */
+    /** Allows to set a constraint regarding the layer placement of a node. Let i be the value of teh constraint. Assumed the drawing has n layers and i < n. If set to i, it expresses that the node should be placed in i-th layer. Should i>=n be true then the node is placed in the last layer of the drawing. Note that this option is not part of any of ELK Layered’s default configurations but is only evaluated as part of the InteractiveLayeredGraphVisitor, which must be applied manually or used via the `DiagramLayoutEngine. */
     "elk.layered.layering.layerChoiceConstraint"?: string;
 
-    /** Layer Constraint */
+    /** Determines a constraint on the placement of the node regarding the layering. */
     "elk.layered.layering.layerConstraint"?: string;
 
-    /** Layer ID */
+    /** Layer identifier that was calculated by ELK Layered for a node. This is only generated if interactiveLayot or generatePositionAndLayerIds is set. */
     "elk.layered.layering.layerId"?: string;
 
-    /** Upper Bound On Width [MinWidth Layerer] */
+    /** Defines a loose upper bound on the width of the MinWidth layerer. If set to ‘-1’ multiple values are tested and the best result is selected. */
     "elk.layered.layering.minWidth.upperBoundOnWidth"?: string;
 
-    /** Upper Layer Estimation Scaling Factor [MinWidth Layerer] */
+    /** Multiplied with Upper Bound On Width for defining an upper bound on the width of layers which haven’t been determined yet, but whose maximum width had been (roughly) estimated by the MinWidth algorithm. Compensates for too high estimations. If set to ‘-1’ multiple values are tested and the best result is selected. */
     "elk.layered.layering.minWidth.upperLayerEstimationScalingFactor"?: string;
 
-    /** Max Node Promotion Iterations */
+    /** Limits the number of iterations for node promotion. */
     "elk.layered.layering.nodePromotion.maxIterations"?: string;
 
-    /** Node Promotion Strategy */
+    /** Reduces number of dummy nodes after layering phase (if possible). */
     "elk.layered.layering.nodePromotion.strategy"?: string;
 
-    /** Node Layering Strategy */
+    /** Strategy for node layering. */
     "elk.layered.layering.strategy"?: string;
 
-    /** Unzipping Layer Split */
+    /** Defines the number of sublayers to split a layer into. The property can be set to the nodes in a layer, which then applies the property for the layer. If multiple nodes set the value to different values, then the lowest value is chosen. */
     "elk.layered.layerUnzipping.layerSplit"?: string;
 
-    /** Minimize Edge Length Heuristic */
+    /** Use a heuristic to decide whether or not to actually perform the layer split with the goal of minimizing the total edge length. This option only works when layerSplit is set to 2. The property can be set to the nodes in a layer, which then applies the property for the layer. If any node sets the value to true, then the value is set to true for the entire layer. */
     "elk.layered.layerUnzipping.minimizeEdgeLength"?: string;
 
-    /** Reset Alternation on Long Edges */
+    /** If set to true, nodes will always be placed in the first sublayer after a long edge when using the ALTERNATING strategy. Otherwise long edge dummies are treated the same as regular nodes. The default value is true. The property can be set to the nodes in a layer, which then applies the property for the layer. If any node sets the value to false, then the value is set to false for the entire layer. */
     "elk.layered.layerUnzipping.resetOnLongEdges"?: string;
 
-    /** Layer Unzipping Strategy */
+    /** The strategy to use for unzipping a layer into multiple sublayers while maintaining the existing ordering of nodes and edges after crossing minimization. The default value is ‘NONE’. */
     "elk.layered.layerUnzipping.strategy"?: string;
 
-    /** Merge Edges */
+    /** Edges that have no ports are merged so they touch the connected nodes at the same points. When this option is disabled, one port is created for each edge directly connected to a node. When it is enabled, all such incoming edges share an input port, and all outgoing edges share an output port. */
     "elk.layered.mergeEdges"?: string;
 
-    /** Merge Hierarchy-Crossing Edges */
+    /** If hierarchical layout is active, hierarchy-crossing edges use as few hierarchical ports as possible. They are broken by the algorithm, with hierarchical ports inserted as required. Usually, one such port is created for each edge at each hierarchy crossing point. With this option set to true, we try to create as few hierarchical ports as possible in the process. In particular, all edges that form a hyperedge can share a port. */
     "elk.layered.mergeHierarchyEdges"?: string;
 
-    /** BK Edge Straightening */
+    /** Specifies whether the Brandes Koepf node placer tries to increase the number of straight edges at the expense of diagram size. There is a subtle difference to the ‘favorStraightEdges’ option, which decides whether a balanced placement of the nodes is desired, or not. In bk terms this means combining the four alignments into a single balanced one, or not. This option on the other hand tries to straighten additional edges during the creation of each of the four alignments. */
     "elk.layered.nodePlacement.bk.edgeStraightening"?: string;
 
-    /** BK Fixed Alignment */
+    /** Tells the BK node placer to use a certain alignment (out of its four) instead of the one producing the smallest height, or the combination of all four. */
     "elk.layered.nodePlacement.bk.fixedAlignment"?: string;
 
-    /** Favor Straight Edges Over Balancing */
+    /** Favor straight edges over a balanced node placement. The default behavior is determined automatically based on the used ’edgeRouting’. For an orthogonal style it is set to true, for all other styles to false. */
     "elk.layered.nodePlacement.favorStraightEdges"?: string;
 
-    /** Linear Segments Deflection Dampening */
+    /** Dampens the movement of nodes to keep the diagram from getting too large. */
     "elk.layered.nodePlacement.linearSegments.deflectionDampening"?: string;
 
-    /** Node Flexibility */
+    /** Aims at shorter and straighter edges. Two configurations are possible: (a) allow ports to move freely on the side they are assigned to (the order is always defined beforehand), (b) additionally allow to enlarge a node wherever it helps. If this option is not configured for a node, the ’nodeFlexibility.default’ value is used, which is specified for the node’s parent. */
     "elk.layered.nodePlacement.networkSimplex.nodeFlexibility"?: string;
 
-    /** Node Flexibility Default */
+    /** Default value of the ’nodeFlexibility’ option for the children of a hierarchical node. */
     "elk.layered.nodePlacement.networkSimplex.nodeFlexibility.default"?: string;
 
-    /** Node Placement Strategy */
+    /** Strategy for node placement. */
     "elk.layered.nodePlacement.strategy"?: string;
 
-    /** Port Sorting Strategy */
+    /** Only relevant for nodes with FIXED_SIDE port constraints. Determines the way a node’s ports are distributed on the sides of a node if their order is not prescribed. The option is set on parent nodes. */
     "elk.layered.portSortingStrategy"?: string;
 
-    /** Direction Priority */
+    /** Defines how important it is to have a certain edge point into the direction of the overall layout. This option is evaluated during the cycle breaking phase. */
     "elk.layered.priority.direction"?: string;
 
-    /** Shortness Priority (ELK Layered) */
+    /** Defines how important it is to keep an edge as short as possible. This option is evaluated during the layering phase. */
     "elk.layered.priority.shortness"?: string;
 
-    /** Straightness Priority */
+    /** Defines how important it is to keep an edge straight, i.e. aligned with one of the two axes. This option is evaluated during node placement. */
     "elk.layered.priority.straightness"?: string;
 
-    /** Spacing Base Value */
+    /** An optional base value for all other layout options of the ‘spacing’ group. It can be used to conveniently alter the overall ‘spaciousness’ of the drawing. Whenever an explicit value is set for the other layout options, this base value will have no effect. The base value is not inherited, i.e. it must be set for each hierarchical node. */
     "elk.layered.spacing.baseValue"?: string;
 
-    /** Edge Edge Between Layer Spacing */
+    /** Spacing to be preserved between pairs of edges that are routed between the same pair of layers. Note that ‘spacing.edgeEdge’ is used for the spacing between pairs of edges crossing the same layer. */
     "elk.layered.spacing.edgeEdgeBetweenLayers"?: string;
 
-    /** Edge Node Between Layers Spacing */
+    /** The spacing to be preserved between nodes and edges that are routed next to the node’s layer. For the spacing between nodes and edges that cross the node’s layer ‘spacing.edgeNode’ is used. */
     "elk.layered.spacing.edgeNodeBetweenLayers"?: string;
 
-    /** Node Node Between Layers Spacing */
+    /** The spacing to be preserved between any pair of nodes of two adjacent layers. Note that ‘spacing.nodeNode’ is used for the spacing between nodes within the layer itself. */
     "elk.layered.spacing.nodeNodeBetweenLayers"?: string;
 
-    /** Thoroughness */
+    /** How much effort should be spent to produce a nice layout. */
     "elk.layered.thoroughness"?: string;
 
-    /** Add Unnecessary Bendpoints */
+    /** Adds bend points even if an edge does not change direction. If true, each long edge dummy will contribute a bend point to its edges and hierarchy-crossing edges will always get a bend point where they cross hierarchy boundaries. By default, bend points are only added where an edge changes direction. */
     "elk.layered.unnecessaryBendpoints"?: string;
 
-    /** Additional Wrapped Edges Spacing */
+    /** To visually separate edges that are wrapped from regularly routed edges an additional spacing value can be specified in form of this layout option. The spacing is added to the regular edgeNode spacing. */
     "elk.layered.wrapping.additionalEdgeSpacing"?: string;
 
-    /** Correction Factor for Wrapping */
+    /** At times and for certain types of graphs the executed wrapping may produce results that are consistently biased in the same fashion: either wrapping to often or to rarely. This factor can be used to correct the bias. Internally, it is simply multiplied with the ‘aspect ratio’ layout option. */
     "elk.layered.wrapping.correctionFactor"?: string;
 
-    /** Manually Specified Cuts */
+    /** Allows the user to specify her own cuts for a certain graph. */
     "elk.layered.wrapping.cutting.cuts"?: string;
 
-    /** MSD Freedom */
+    /** The MSD cutting strategy starts with an initial guess on the number of chunks the graph should be split into. The freedom specifies how much the strategy may deviate from this guess. E.g. if an initial number of 3 is computed, a freedom of 1 allows 2, 3, and 4 cuts. */
     "elk.layered.wrapping.cutting.msd.freedom"?: string;
 
-    /** Cutting Strategy */
+    /** The strategy by which the layer indexes are determined at which the layering crumbles into chunks. */
     "elk.layered.wrapping.cutting.strategy"?: string;
 
-    /** Distance Penalty When Improving Cuts */
     "elk.layered.wrapping.multiEdge.distancePenalty"?: string;
 
-    /** Improve Cuts */
+    /** For general graphs it is important that not too many edges wrap backwards. Thus a compromise between evenly-distributed cuts and the total number of cut edges is sought. */
     "elk.layered.wrapping.multiEdge.improveCuts"?: string;
 
-    /** Improve Wrapped Edges */
+    /** The initial wrapping is performed in a very simple way. As a consequence, edges that wrap from one chunk to another may be unnecessarily long. Activating this option tries to shorten such edges. */
     "elk.layered.wrapping.multiEdge.improveWrappedEdges"?: string;
 
-    /** Graph Wrapping Strategy */
+    /** For certain graphs and certain prescribed drawing areas it may be desirable to split the laid out graph into chunks that are placed side by side. The edges that connect different chunks are ‘wrapped’ around from the end of one chunk to the start of the other chunk. The points between the chunks are referred to as ‘cuts’. */
     "elk.layered.wrapping.strategy"?: string;
 
-    /** Valid Indices for Wrapping */
     "elk.layered.wrapping.validify.forbiddenIndices"?: string;
 
-    /** Validification Strategy */
+    /** When wrapping graphs, one can specify indices that are not allowed as split points. The validification strategy makes sure every computed split point is allowed. */
     "elk.layered.wrapping.validify.strategy"?: string;
 
-    /** Layout Ancestors */
+    /** Whether the hierarchy levels on the path from the selected element to the root of the diagram shall be included in the layout process. */
     "elk.layoutAncestors"?: string;
 
-    /** Margins */
+    /** Margins define additional space around the actual bounds of a graph element. For instance, ports or labels being placed on the outside of a node’s border might introduce such a margin. The margin is used to guarantee non-overlap of other graph elements with those ports or labels. */
     "elk.margins"?: string;
 
-    /** Maximal Animation Time */
+    /** The maximal time for animations, in milliseconds. */
     "elk.maxAnimTime"?: string;
 
-    /** Minimal Animation Time */
+    /** The minimal time for animations, in milliseconds. */
     "elk.minAnimTime"?: string;
 
-    /** Position Constraint */
+    /** Turns on Tree compaction which decreases the size of the whole tree by placing nodes of multiple levels in one large level */
     "elk.mrtree.compaction"?: string;
 
-    /** Edge End Texture Length */
+    /** Should be set to the length of the texture at the end of an edge. This value can be used to improve the Edge Routing. */
     "elk.mrtree.edgeEndTextureLength"?: string;
 
-    /** Edge Routing Mode */
+    /** Chooses an Edge Routing algorithm. */
     "elk.mrtree.edgeRoutingMode"?: string;
 
-    /** Position Constraint */
+    /** When set to a positive number this option will force the algorithm to place the node to the specified position within the trees layer if weighting is set to constraint */
     "elk.mrtree.positionConstraint"?: string;
 
-    /** Search Order */
+    /** Which search order to use when computing a spanning tree. */
     "elk.mrtree.searchOrder"?: string;
 
-    /** Tree Level */
+    /** The index for the tree level the node is in */
     "elk.mrtree.treeLevel"?: string;
 
-    /** Weighting of Nodes */
+    /** Which weighting to use when computing a node order. */
     "elk.mrtree.weighting"?: string;
 
-    /** Node Label Padding */
+    /** Define padding for node labels that are placed inside of a node. */
     "elk.nodeLabels.padding"?: string;
 
-    /** Node Label Placement */
+    /** Hints for where node labels are to be placed; if empty, the node label’s position is not modified. */
     "elk.nodeLabels.placement"?: string;
 
-    /** Node Size Constraints */
+    /** What should be taken into account when calculating a node’s size. Empty size constraints specify that a node’s size is already fixed and should not be changed. */
     "elk.nodeSize.constraints"?: string;
 
-    /** Fixed Graph Size */
+    /** By default, the fixed layout provider will enlarge a graph until it is large enough to contain its children. If this option is set, it won’t do so. */
     "elk.nodeSize.fixedGraphSize"?: string;
 
-    /** Node Size Minimum */
+    /** The minimal size to which a node can be reduced. */
     "elk.nodeSize.minimum"?: string;
 
-    /** Node Size Options */
+    /** Options modifying the behavior of the size constraints set on a node. Each member of the set specifies something that should be taken into account when calculating node sizes. The empty set corresponds to no further modifications. */
     "elk.nodeSize.options"?: string;
 
-    /** No Layout */
+    /** No layout is done for the associated element. This is used to mark parts of a diagram to avoid their inclusion in the layout graph, or to mark parts of the layout graph to prevent layout engines from processing them. If you wish to exclude the contents of a compound node from automatic layout, while the node itself is still considered on its own layer, use the ‘Fixed Layout’ algorithm for that node. */
     "elk.noLayout"?: string;
 
-    /** Omit Node Micro Layout */
+    /** Node micro layout comprises the computation of node dimensions (if requested), the placement of ports and their labels, and the placement of node labels. The functionality is implemented independent of any specific layout algorithm and shouldn’t have any negative impact on the layout algorithm’s performance itself. Yet, if any unforeseen behavior occurs, this option allows to deactivate the micro layout. */
     "elk.omitNodeMicroLayout"?: string;
 
-    /** Upper limit for iterations of overlap removal */
     "elk.overlapRemoval.maxIterations"?: string;
 
-    /** Whether to run a supplementary scanline overlap check. */
     "elk.overlapRemoval.runScanline"?: string;
 
-    /** Padding */
+    /** The padding to be left to a parent element’s border when placing child elements. This can also serve as an output option of a layout algorithm if node size calculation is setup appropriately. */
     "elk.padding"?: string;
 
-    /** Layout Partitioning */
+    /** Whether to activate partitioned layout. This will allow to group nodes through the Layout Partition option. a pair of nodes with different partition indices is then placed such that the node with lower index is placed to the left of the other node (with left-to-right layout direction). Depending on the layout algorithm, this may only be guaranteed to work if all nodes have a layout partition configured, or at least if edges that cross partitions are not part of a partition-crossing cycle. */
     "elk.partitioning.activate"?: string;
 
-    /** Layout Partition */
+    /** Partition to which the node belongs. This requires Layout Partitioning to be active. Nodes with lower partition IDs will appear to the left of nodes with higher partition IDs (assuming a left-to-right layout direction). */
     "elk.partitioning.partition"?: string;
 
-    /** Fill Polyominoes */
+    /** Use the Profile Fill algorithm to fill polyominoes to prevent small polyominoes from being placed inside of big polyominoes with large holes. Might increase packing area. */
     "elk.polyomino.fill"?: string;
 
-    /** Polyomino Primary Sorting Criterion */
+    /** Possible primary sorting criteria for the processing order of polyominoes. */
     "elk.polyomino.highLevelSort"?: string;
 
-    /** Polyomino Secondary Sorting Criterion */
+    /** Possible secondary sorting criteria for the processing order of polyominoes. They are used when polyominoes are equal according to the primary sorting criterion HighLevelSortingCriterion. */
     "elk.polyomino.lowLevelSort"?: string;
 
-    /** Polyomino Traversal Strategy */
+    /** Traversal strategy for trying different candidate positions for polyominoes. */
     "elk.polyomino.traversalStrategy"?: string;
 
-    /** Port Anchor Offset */
+    /** The offset to the port position where connections shall be attached. */
     "elk.port.anchor"?: string;
 
-    /** Port Border Offset */
+    /** The offset of ports on the node border. With a positive offset the port is moved outside of the node, while with a negative offset the port is moved towards the inside. An offset of 0 means that the port is placed directly on the node border, i.e. if the port side is north, the port’s south border touches the nodes’s north border; if the port side is east, the port’s west border touches the nodes’s east border; if the port side is south, the port’s north border touches the node’s south border; if the port side is west, the port’s east border touches the node’s west border. */
     "elk.port.borderOffset"?: string;
 
-    /** Port Index */
+    /** The index of a port in the fixed order around a node. The order is assumed as clockwise, starting with the leftmost port on the top side. This option must be set if ‘Port Constraints’ is set to FIXED_ORDER and no specific positions are given for the ports. Additionally, the option ‘Port Side’ must be defined in this case. */
     "elk.port.index"?: string;
 
-    /** Port Side */
+    /** The side of a node on which a port is situated. This option must be set if ‘Port Constraints’ is set to FIXED_SIDE or FIXED_ORDER and no specific positions are given for the ports. */
     "elk.port.side"?: string;
 
-    /** Port Alignment */
+    /** Defines the default port distribution for a node. May be overridden for each side individually. */
     "elk.portAlignment.default"?: string;
 
-    /** Port Alignment (East) */
+    /** Defines how ports on the eastern side are placed, overriding the node’s general port alignment. */
     "elk.portAlignment.east"?: string;
 
-    /** Port Alignment (North) */
+    /** Defines how ports on the northern side are placed, overriding the node’s general port alignment. */
     "elk.portAlignment.north"?: string;
 
-    /** Port Alignment (South) */
+    /** Defines how ports on the southern side are placed, overriding the node’s general port alignment. */
     "elk.portAlignment.south"?: string;
 
-    /** Port Alignment (West) */
+    /** Defines how ports on the western side are placed, overriding the node’s general port alignment. */
     "elk.portAlignment.west"?: string;
 
-    /** Port Constraints */
+    /** Defines constraints of the position of the ports of a node. */
     "elk.portConstraints"?: string;
 
-    /** Port Labels Next to Port */
+    /** Use ‘portLabels.placement’: NEXT_TO_PORT_OF_POSSIBLE. */
     "elk.portLabels.nextToPortIfPossible"?: string;
 
-    /** Port Label Placement */
+    /** Decides on a placement method for port labels; if empty, the node label’s position is not modified. */
     "elk.portLabels.placement"?: string;
 
-    /** Treat Port Labels as Group */
+    /** If this option is true (default), the labels of a port will be treated as a group when it comes to centering them next to their port. If this option is false, only the first label will be centered next to the port, with the others being placed below. This only applies to labels of eastern and western ports and will have no effect if labels are not placed next to their port. */
     "elk.portLabels.treatAsGroup"?: string;
 
-    /** Position */
+    /** The position of a node, port, or label. This is used by the ‘Fixed Layout’ algorithm to specify a pre-defined position. */
     "elk.position"?: string;
 
-    /** Priority (ELK Mr. Tree) */
+    /** Defines the priority of an object; its meaning depends on the specific layout algorithm and the context where it is used. */
     "elk.priority"?: string;
 
-    /** Root node for spanning tree construction */
+    /** The identifier of the node that is preferred as the root of the spanning tree. If this is null, the first node is chosen. */
     "elk.processingOrder.preferredRoot"?: string;
 
-    /** Root selection for spanning tree */
+    /** This sets the method used to select a root node for the construction of a spanning tree */
     "elk.processingOrder.rootSelection"?: string;
 
-    /** Cost Function for Spanning Tree */
+    /** The cost function is used in the creation of the spanning tree. */
     "elk.processingOrder.spanningTreeCostFunction"?: string;
 
-    /** Tree Construction Strategy */
+    /** Whether a minimum spanning tree or a maximum spanning tree should be constructed. */
     "elk.processingOrder.treeConstruction"?: string;
 
-    /** Progress Bar */
+    /** Whether a progress bar shall be displayed during layout computations. */
     "elk.progressBar"?: string;
 
-    /** Center On Root */
+    /** Centers the layout on the root of the tree i.e. so that the central node is also the center node of the final layout. This introduces additional whitespace. */
     "elk.radial.centerOnRoot"?: string;
 
-    /** Compaction Step Size */
+    /** Determine the size of steps with which the compaction is done. Step size 1 correlates to a compaction of 1 pixel per Iteration. */
     "elk.radial.compactionStepSize"?: string;
 
-    /** Compaction */
+    /** With the compacter option it can be determined how compaction on the graph is done. It can be chosen between none, the radial compaction or the compaction of wedges separately. */
     "elk.radial.compactor"?: string;
 
-    /** Translation Optimization */
+    /** Find the optimal translation of the nodes of the first radii according to this criteria. For example edge crossings can be minimized. */
     "elk.radial.optimizationCriteria"?: string;
 
-    /** Order ID */
+    /** The id can be used to define an order for nodes of one radius. This can be used to sort them in the layer accordingly. */
     "elk.radial.orderId"?: string;
 
-    /** Radius */
+    /** The radius option can be used to set the initial radius for the radial layouter. */
     "elk.radial.radius"?: string;
 
-    /** Rotate */
+    /** The rotate option determines whether a rotation of the layout should be performed. */
     "elk.radial.rotate"?: string;
 
-    /** Additional Wedge Space */
+    /** If set to true, modifies the target angle by rotating further such that space is left for an edge to pass in between the nodes. This option should only be used in conjunction with top-down layout. */
     "elk.radial.rotation.computeAdditionalWedgeSpace"?: string;
 
-    /** Outgoing Edge Angles */
+    /** Calculate the required angle of connected nodes to leave space for an incoming edge. This option should only be used in conjunction with top-down layout. */
     "elk.radial.rotation.outgoingEdgeAngles"?: string;
 
-    /** Target Angle */
+    /** The angle in radians that the layout should be rotated to after layout. */
     "elk.radial.rotation.targetAngle"?: string;
 
-    /** Sorter */
+    /** Sort the nodes per radius according to the sorting algorithm. The strategies are none, by the given order id, or sorting them by polar coordinates. */
     "elk.radial.sorter"?: string;
 
-    /** Annulus Wedge Criteria */
+    /** Determine how the wedge for the node placement is calculated. It can be chosen between wedge determination by the number of leaves or by the maximum sum of diagonals. */
     "elk.radial.wedgeCriteria"?: string;
 
-    /** Randomization Seed */
+    /** Seed used for pseudo-random number generators to control the layout algorithm. If the value is 0, the seed shall be determined pseudo-randomly (e.g. from the system time). */
     "elk.randomSeed"?: string;
 
-    /** Current position of a node in the order of nodes */
+    /** The rectangles are ordered. Normally according to their definition the the model. This option specifies the current position of a node. */
     "elk.rectpacking.currentPosition"?: string;
 
-    /** Desired index of node */
+    /** The rectangles are ordered. Normally according to their definition the the model. This option allows to specify a desired position that has preference over the original position. */
     "elk.rectpacking.desiredPosition"?: string;
 
-    /** In new Row */
+    /** If set to true this node begins in a new row. Consequently this node cannot be moved in a previous layer during compaction. Width approximation does does not take this into account. */
     "elk.rectpacking.inNewRow"?: string;
 
-    /** Order nodes by height */
+    /** If set to true the nodes will be sorted by their height before computing the layout. The largest node will be in the first position. */
     "elk.rectpacking.orderBySize"?: string;
 
-    /** Compaction iterations */
+    /** Defines the number of compaction iterations. E.g. if set to 2 the width is initially approximated, then the drawing is compacted and based on the resulting drawing the target width is decreased or increased and a second compaction step is executed and the result compared to the first one. The best run is used based on the scale measure. */
     "elk.rectpacking.packing.compaction.iterations"?: string;
 
-    /** Row Height Reevaluation */
+    /** During the compaction step the height of a row is normally not changed. If this options is set, the blocks of other rows might be added if they exceed the row height. If this is the case the whole row has to be packed again to be optimal regarding the new row height. This option should, therefore, be used with care since it might be computation heavy. */
     "elk.rectpacking.packing.compaction.rowHeightReevaluation"?: string;
 
-    /** Compaction Strategy */
+    /** Strategy for finding an initial placement on nodes. */
     "elk.rectpacking.packing.strategy"?: string;
 
-    /** Try box layout first */
+    /** Whether one should check whether the regions are stackable to see whether box layout would do the job. For example, nodes with the same height are not stackable inside a row. Therefore, box layout will perform better and faster. */
     "elk.rectpacking.trybox"?: string;
 
-    /** White Space Approximation Strategy */
+    /** Strategy for expanding nodes such that whitespace in the parent is eliminated. */
     "elk.rectpacking.whiteSpaceElimination.strategy"?: string;
 
-    /** Shift Last Placed. */
+    /** When placing a rectangle behind or below the last placed rectangle in the first iteration, it is sometimes possible to shift the rectangle further to the left or right, resulting in less whitespace. True (default) enables the shift and false disables it. Disabling the shift produces a greater approximated area by the first iteration and a layout, when using ONLY the first iteration (default not the case), where it is sometimes impossible to implement a size transformation of rectangles that will fill the bounding box and eliminate empty spaces. */
     "elk.rectpacking.widthApproximation.lastPlaceShift"?: string;
 
-    /** Optimization Goal */
+    /** Optimization goal for approximation of the bounding box given by the first iteration. Determines whether layout is sorted by the maximum scaling, aspect ratio, or area. Depending on the strategy the aspect ratio might be nearly ignored. */
     "elk.rectpacking.widthApproximation.optimizationGoal"?: string;
 
-    /** Width Approximation Strategy */
+    /** Strategy for finding an initial width of the drawing. */
     "elk.rectpacking.widthApproximation.strategy"?: string;
 
-    /** Target Width */
+    /** Option to place the rectangles in the given target width instead of approximating the width using the desired aspect ratio. The padding is not included in this. Meaning a drawing will have width of targetwidth + horizontal padding. */
     "elk.rectpacking.widthApproximation.targetWidth"?: string;
 
-    /** Resolved Layout Algorithm */
+    /** Meta data associated with the selected algorithm. */
     "elk.resolvedAlgorithm"?: string;
 
-    /** Scale Factor */
+    /** The scaling factor to be applied to the corresponding node in recursive layout. It causes the corresponding node’s size to be adjusted, and its ports and labels to be sized and placed accordingly after the layout of that node has been determined (and before the node itself and its siblings are arranged). The scaling is not reverted afterwards, so the resulting layout graph contains the adjusted size and position data. This option is currently not supported if ‘Layout Hierarchy’ is set. */
     "elk.scaleFactor"?: string;
 
-    /** Separate Connected Components */
+    /** Whether each connected component should be processed separately. */
     "elk.separateConnectedComponents"?: string;
 
-    /** Softwrapping Fuzziness */
+    /** Determines the amount of fuzziness to be used when performing softwrapping on labels. The value expresses the percent of overhang that is permitted for each line. If the next line would take up less space than this threshold, it is appended to the current line instead of being placed in a new line. */
     "elk.softwrappingFuzziness"?: string;
 
-    /** Comment Comment Spacing */
+    /** Spacing to be preserved between a comment box and other comment boxes connected to the same node. The space left between comment boxes of different nodes is controlled by the node-node spacing. */
     "elk.spacing.commentComment"?: string;
 
-    /** Comment Node Spacing */
+    /** Spacing to be preserved between a node and its connected comment boxes. The space left between a node and the comments of another node is controlled by the node-node spacing. */
     "elk.spacing.commentNode"?: string;
 
-    /** Components Spacing */
+    /** Spacing to be preserved between pairs of connected components. This option is only relevant if ‘separateConnectedComponents’ is activated. */
     "elk.spacing.componentComponent"?: string;
 
-    /** Edge Spacing */
+    /** Spacing to be preserved between any two edges. Note that while this can somewhat easily be satisfied for the segments of orthogonally drawn edges, it is harder for general polylines or splines. */
     "elk.spacing.edgeEdge"?: string;
 
-    /** Edge Label Spacing */
+    /** The minimal distance to be preserved between a label and the edge it is associated with. Note that the placement of a label is influenced by the ’edgelabels.placement’ option. */
     "elk.spacing.edgeLabel"?: string;
 
-    /** Edge Node Spacing */
+    /** Spacing to be preserved between nodes and edges. */
     "elk.spacing.edgeNode"?: string;
 
-    /** Individual Spacing (ELK Layered) */
+    /** Allows to specify individual spacing values for graph elements that shall be different from the value specified for the element’s parent. */
     "elk.spacing.individual"?: string;
 
-    /** Label Spacing */
+    /** Determines the amount of space to be left between two labels of the same graph element. */
     "elk.spacing.labelLabel"?: string;
 
-    /** Label Node Spacing */
+    /** Spacing to be preserved between labels and the border of node they are associated with. Note that the placement of a label is influenced by the ’nodelabels.placement’ option. */
     "elk.spacing.labelNode"?: string;
 
-    /** Horizontal spacing between Label and Port */
+    /** Horizontal spacing to be preserved between labels and the ports they are associated with. Note that the placement of a label is influenced by the ‘portlabels.placement’ option. */
     "elk.spacing.labelPortHorizontal"?: string;
 
-    /** Vertical spacing between Label and Port */
+    /** Vertical spacing to be preserved between labels and the ports they are associated with. Note that the placement of a label is influenced by the ‘portlabels.placement’ option. */
     "elk.spacing.labelPortVertical"?: string;
 
-    /** Node Spacing */
+    /** The minimal distance to be preserved between each two nodes. */
     "elk.spacing.nodeNode"?: string;
 
-    /** Node Self Loop Spacing */
+    /** Spacing to be preserved between a node and its self loops. */
     "elk.spacing.nodeSelfLoop"?: string;
 
-    /** Port Spacing */
+    /** Spacing between pairs of ports of the same node. */
     "elk.spacing.portPort"?: string;
 
-    /** Additional Port Space */
+    /** Additional space around the sets of ports on each node side. For each side of a node, this option can reserve additional space before and after the ports on each side. For example, a top spacing of 20 makes sure that the first port on the western and eastern side is 20 units away from the northern border. */
     "elk.spacing.portsSurrounding"?: string;
 
-    /** Desired Edge Length */
+    /** Either specified for parent nodes or for individual edges, where the latter takes higher precedence. */
     "elk.stress.desiredEdgeLength"?: string;
 
-    /** Layout Dimension */
+    /** Dimensions that are permitted to be altered during layout. */
     "elk.stress.dimension"?: string;
 
-    /** Stress Epsilon */
+    /** Termination criterion for the iterative process. */
     "elk.stress.epsilon"?: string;
 
-    /** Fixed Position */
+    /** Prevent that the node is moved by the layout algorithm. */
     "elk.stress.fixed"?: string;
 
-    /** Iteration Limit */
+    /** Maximum number of performed iterations. Takes higher precedence than ’epsilon'. */
     "elk.stress.iterationLimit"?: string;
 
-    /** Structure Extraction Strategy */
+    /** This option defines what kind of triangulation or other partitioning of the plane is applied to the vertices. */
     "elk.structure.structureExtractionStrategy"?: string;
 
-    /** Topdown Hierarchical Node Aspect Ratio */
+    /** The fixed aspect ratio of a hierarchical node when using topdown layout. Default is 1/sqrt(2). If this value is set on a parallel node it applies to its children, when set on a hierarchical node it applies to the node itself. */
     "elk.topdown.hierarchicalNodeAspectRatio"?: string;
 
-    /** Topdown Hierarchical Node Width */
+    /** The fixed size of a hierarchical node when using topdown layout. If this value is set on a parallel node it applies to its children, when set on a hierarchical node it applies to the node itself. */
     "elk.topdown.hierarchicalNodeWidth"?: string;
 
-    /** Topdown Node Type */
+    /** The different node types used for topdown layout. If the node type is set to {@link TopdownNodeTypes.PARALLEL_NODE} the algorithm must be set to a {@link TopdownLayoutProvider} such as {@link TopdownPacking}. The {@link nodeSize.fixedGraphSize} option is technically only required for hierarchical nodes. */
     "elk.topdown.nodeType"?: string;
 
-    /** Topdown Scale Cap */
+    /** Determines the upper limit for the topdown scale factor. The default value is 1.0 which ensures that nested children never end up appearing larger than their parents in terms of unit sizes such as the font size. If the limit is larger, nodes will fully utilize the available space, but it is counteriniuitive for inner nodes to have a larger scale than outer nodes. */
     "elk.topdown.scaleCap"?: string;
 
-    /** Topdown Scale Factor */
+    /** The scaling factor to be applied to the nodes laid out within the node in recursive topdown layout. The difference to ‘Scale Factor’ is that the node itself is not scaled. This value has to be set on hierarchical nodes. */
     "elk.topdown.scaleFactor"?: string;
 
-    /** Topdown Size Approximator */
+    /** The size approximator to be used to set sizes of hierarchical nodes during topdown layout. The default value is null, which results in nodes keeping whatever size is defined for them e.g. through parent parallel node or by manually setting the size. */
     "elk.topdown.sizeApproximator"?: string;
 
-    /** Number of size categories */
+    /** Defines the number of categories to use for the FIXED_INTEGER_RATIO_BOXES size approximator. */
     "elk.topdown.sizeCategories"?: string;
 
-    /** Weight of a node containing children for determining the graph size */
+    /** When determining the graph size for the size categorisation, this value determines how many times a node containing children is weighted more than a simple node. For example setting this value to four would result in a graph containing a simple node and a hierarchical node to be counted as having a size of five. */
     "elk.topdown.sizeCategoriesHierarchicalNodeWeight"?: string;
 
-    /** Topdown Layout */
+    /** Turns topdown layout on and off. If this option is enabled, hierarchical layout will be computed first for the root node and then for its children recursively. Layouts are then scaled down to fit the area provided by their parents. Graphs must follow a certain structure for topdown layout to work properly. {@link TopdownNodeTypes.PARALLEL_NODE} nodes must have children of type {@link TopdownNodeTypes.HIERARCHICAL_NODE} and must define {@link topdown.hierarchicalNodeWidth} and {@link topdown.hierarchicalNodeAspectRatio} for their children. Furthermore they need to be laid out using an algorithm that is a {@link TopdownLayoutProvider}. Hierarchical nodes can also be parents of other hierarchical nodes and can optionally use a {@link TopdownSizeApproximator} to dynamically set sizes during topdown layout. In this case {@link topdown.hierarchicalNodeWidth} and {@link topdown.hierarchicalNodeAspectRatio} should be set on the node itself rather than the parent. The values are then used by the size approximator as base values. Hierarchical nodes require the layout option {@link nodeSize.fixedGraphSize} to be true to prevent the algorithm used there from resizing the hierarchical node. This option is not supported if ‘Hierarchy Handling’ is set to ‘INCLUDE_CHILDREN’ */
     "elk.topdownLayout"?: string;
 
-    /** Node arrangement strategy */
+    /** Strategy for node arrangement. The strategy determines the size of the resulting graph. */
     "elk.topdownpacking.nodeArrangement.strategy"?: string;
 
-    /** Whitespace elimination strategy */
+    /** Strategy for whitespace elimination. */
     "elk.topdownpacking.whitespaceElimination.strategy"?: string;
 
-    /** Underlying Layout Algorithm */
+    /** A layout algorithm that is applied to the graph before it is compacted. If this is null, nothing is applied before compaction. */
     "elk.underlyingLayoutAlgorithm"?: string;
 
-    /** Validate Graph */
+    /** Whether the graph shall be validated before any layout algorithm is applied. If this option is enabled and at least one error is found, the layout process is aborted and a message is shown to the user. */
     "elk.validateGraph"?: string;
 
-    /** Validate Options */
+    /** Whether layout options shall be validated before any layout algorithm is applied. If this option is enabled and at least one error is found, the layout process is aborted and a message is shown to the user. */
     "elk.validateOptions"?: string;
 
-    /** Consider node model order */
+    /** Consider node model as a secondary criterion when using straight line routing. */
     "elk.vertiflex.considerNodeModelOrder"?: string;
 
-    /** Layer distance */
+    /** The distance to use between nodes of different layers if no vertical constraints are set. */
     "elk.vertiflex.layerDistance"?: string;
 
-    /** Edge layout strategy */
+    /** Strategy for the layout of the children. ‘straight’ for straight line drawings, ‘bend’ for a possible bend. When straight edges are prioritized the nodes will be reordered in order to guarantee that straight edges are possible. If bend points are enabled on the other hand, the given model order of the nodes is maintained and bend points are introduced to prevent edge node overlaps. */
     "elk.vertiflex.layoutStrategy"?: string;
 
-    /** Fixed vertical position */
+    /** The Y position that the node should be fixed at. */
     "elk.vertiflex.verticalConstraint"?: string;
 
-    /** Zoom to Fit */
+    /** Whether the zoom level shall be set to view the whole diagram after layout. */
     "elk.zoomToFit"?: string;
 
     [key: string]: any;


### PR DESCRIPTION
Many have already reported this, some have tried to improve it with automatic type generation. I have decided to take a more pragmatic approach by just hardcoding all the options from the official elk options [doc](https://www.eclipse.org/elk/reference/options.html).

I am not even going to pretend that I have done some sort of Herculean work, all the credit goes to the official elk doc.
All that I have really done is to copy paste this webscraper into the devtools of the official elk options [doc](https://www.eclipse.org/elk/reference/options.html):
```
async function extractOptionsWithFetchedDescriptions() {
	const rows = [...document.querySelectorAll('table.table tbody tr')];

	const entries = await Promise.all(rows.map(async tr => {
		const tds = tr.querySelectorAll('td');
		const link = tds[0]?.querySelector('a');
		const key = tds[1]?.querySelector('code')?.textContent.trim();

		if (!key || !link?.href) return null;

		let description = '';

		try {
			const html = await fetch(link.href).then(r => r.text());
			const doc = new DOMParser().parseFromString(html, 'text/html');

			const heading = doc.querySelector('#description');
			const paragraph = heading?.nextElementSibling;

			description = paragraph?.tagName === 'P'
				? paragraph.textContent.trim()
				: '';
		} catch (err) {
			console.warn('Failed to fetch description for', key, link.href, err);
		}

		return { key, description };
	}));

	return entries.filter(Boolean);
}

function generateLayoutOptionsInterface(entries) {
  const uniqueMap = new Map();

  for (const e of entries) {
    if (e && e.key) {
      uniqueMap.set(e.key, e);
    }
  }

  const unique = Array.from(uniqueMap.values())
    .sort((a, b) => a.key.localeCompare(b.key));

  const lines = unique.map(({ key, description }) => {
    const comment = description
      ? `    /** ${description.replace(/\*\//g, '')} */\n`
      : '';
    return `${comment}    "${key.replaceAll("org.eclipse.", "")}"?: string;`;
  }).join('\n\n');

  return `export interface LayoutOptions {\n${lines}\n\n    [key: string]: string | undefined;\n}`;
}

const entries = await extractOptionsWithFetchedDescriptions();
const result = generateLayoutOptionsInterface(entries);

const blob = new Blob([result], { type: 'text/plain;charset=utf-8' });
const url = URL.createObjectURL(blob);

const a = document.createElement('a');
a.href = url;
a.download = 'LayoutOptions.ts';
a.click();

URL.revokeObjectURL(url);
```
And added some options manually...

I am also not going to pretend that this solution is perfect because it certainly is not, but neither is the current LayoutOptions as that thing is next to useless to the point that its bearly worth importing, like for real, you can just default to "any" time and the effect is going to be the same. But I am not going to dump on it as that was already done quite a few times in the [issues](https://github.com/kieler/elkjs/issues/113), I am not here for that I am here to provide a solution that provides already a great step up in the dev experience while should remaining completely compatible with everything else.
With this, you can already see all (most of) the available options directly in your editor with appropriate documentation:
<img width="793" height="331" alt="image" src="https://github.com/user-attachments/assets/94cfbf1c-6a38-499a-ad16-470b50adb78a" />

It would be great to have this in elk, since I think that many would agree that this is de-facto a great bang for your buck / long hanging fruit kind of thing (that should have been grabbed a long time ago if you ask me...) that, although not perfect, already improves quite a lot (Speaking from the experience, I am using this in my project and it works great).

If not desirable to merge, it would be great to at least have the provided webscraper in the docs to help anyone get the proper typing with minimal effort 
