### PR TITLE
Remove EOL Node 14.x from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [ 14.x, 24.x ]
+        node-version: [ 24.x ]
         java-version: [ 17 ] 
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [ 24.x ]
+        node-version: [ 24.x, 26.x ]
         java-version: [ 17 ] 
 
     steps:


### PR DESCRIPTION
Node 14.x has been end-of-life since April 2023.